### PR TITLE
Fix: intégration de Vosk Small FR pour OpenEER

### DIFF
--- a/app/src/main/java/com/example/openeer/audio/RecorderService.kt
+++ b/app/src/main/java/com/example/openeer/audio/RecorderService.kt
@@ -11,6 +11,8 @@ import com.example.openeer.data.AppDatabase
 import com.example.openeer.data.NoteRepository
 import kotlinx.coroutines.*
 import com.example.openeer.core.getOneShotPlace
+import com.example.openeer.stt.VoskTranscriber
+import java.io.File
 
 class RecorderService : Service() {
 
@@ -87,6 +89,12 @@ class RecorderService : Service() {
 
             if (noteId != 0L && wav != null) {
                 runCatching { repo.updateAudio(noteId, wav) }
+                val text = runCatching {
+                    VoskTranscriber.transcribe(this@RecorderService, File(wav))
+                }.getOrNull()
+                if (!text.isNullOrBlank()) {
+                    runCatching { repo.setBody(noteId, text) }
+                }
             }
 
             // Broadcast retour (noteId + chemin wav)

--- a/app/src/main/java/com/example/openeer/stt/VoskTranscriber.kt
+++ b/app/src/main/java/com/example/openeer/stt/VoskTranscriber.kt
@@ -7,7 +7,6 @@ import org.vosk.Model
 import org.vosk.Recognizer
 import java.io.File
 import java.io.FileOutputStream
-import org.vosk.android.StorageService
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicReference

--- a/app/src/main/java/com/example/openeer/ui/LiveTranscriber.kt
+++ b/app/src/main/java/com/example/openeer/ui/LiveTranscriber.kt
@@ -1,4 +1,32 @@
 package com.example.openeer.ui
 
-class LiveTranscriber {
+import android.content.Context
+import com.example.openeer.stt.VoskTranscriber
+
+/**
+ * Petit wrapper utilitaire autour de [VoskTranscriber] pour gérer
+ * une session de reconnaissance vocale en continu.
+ */
+class LiveTranscriber(private val ctx: Context) {
+    private var session: VoskTranscriber.StreamingSession? = null
+
+    /** Démarre une nouvelle session de transcription. */
+    fun start() {
+        session = VoskTranscriber.startStreaming(ctx)
+    }
+
+    /** Alimente la session en PCM 16 kHz mono. */
+    fun feed(pcm: ShortArray) {
+        session?.feed(pcm)
+    }
+
+    /** Récupère une hypothèse partielle. */
+    fun partial(): String = session?.partial() ?: ""
+
+    /** Termine la session et renvoie le texte final. */
+    fun stop(): String {
+        val txt = session?.finish().orEmpty()
+        session = null
+        return txt
+    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,12 +12,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // ✅ AAR local Coquí (chemin relatif depuis la racine du projet)
-        flatDir {
-            // Si ton AAR est dans app/libs/
-            dirs(file("app/libs"))
-            // Si un jour tu déplaces l'AAR ailleurs, ajuste le chemin ici.
-        }
+        // Dépôts Maven habituels uniquement, le modèle Vosk est fourni via assets.
     }
 }
 


### PR DESCRIPTION
## Summary
- configure project to rely solely on Vosk Android artifact and embedded `vosk-fr` assets
- route recording workflow through `VoskTranscriber` and add helper for live transcription
- remove leftover Coqui references from Gradle settings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b801b91c832d9a5cebd6030496ea