### PR TITLE
Fix Vosk crash by serializing audio feed

### DIFF
--- a/app/src/main/java/com/example/openeer/stt/MicRecorder.kt
+++ b/app/src/main/java/com/example/openeer/stt/MicRecorder.kt
@@ -11,17 +11,20 @@ import kotlin.math.min
 @Suppress("MissingPermission")
 
 class MicRecorder(
-    private val sampleRate: Int = 16000
+    private val sampleRate: Int = DEFAULT_SAMPLE_RATE
 ) {
+    companion object {
+        /** Sample rate matching Vosk recognizer (mono/PCM16) */
+        const val DEFAULT_SAMPLE_RATE = 16_000
+    }
+
+    private val channelConfig = AudioFormat.CHANNEL_IN_MONO
+    private val audioFormat = AudioFormat.ENCODING_PCM_16BIT
     private var audioRecord: AudioRecord? = null
     private var bufferSize: Int = 0
 
     fun start(): Boolean {
-        val minBuf = AudioRecord.getMinBufferSize(
-            sampleRate,
-            AudioFormat.CHANNEL_IN_MONO,
-            AudioFormat.ENCODING_PCM_16BIT
-        )
+        val minBuf = AudioRecord.getMinBufferSize(sampleRate, channelConfig, audioFormat)
         if (minBuf <= 0) return false
 
         // ~200 ms de tampon min (en bytes)
@@ -30,8 +33,8 @@ class MicRecorder(
         audioRecord = AudioRecord(
             MediaRecorder.AudioSource.VOICE_RECOGNITION, // AGC/NS souvent meilleurs
             sampleRate,
-            AudioFormat.CHANNEL_IN_MONO,
-            AudioFormat.ENCODING_PCM_16BIT,
+            channelConfig,
+            audioFormat,
             bufferSize
         )
 

--- a/app/src/main/java/com/example/openeer/stt/VoskTranscriber.kt
+++ b/app/src/main/java/com/example/openeer/stt/VoskTranscriber.kt
@@ -2,19 +2,21 @@ package com.example.openeer.stt
 
 import android.content.Context
 import android.util.Log
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
 import org.vosk.Model
 import org.vosk.Recognizer
 import java.io.File
 import java.io.FileOutputStream
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicReference
 
 object VoskTranscriber {
 
     private const val TAG = "Vosk"
-    private const val SAMPLE_RATE = 16000f
+    /** Sample rate (Hz) expected by both AudioRecord and Vosk recognizer */
+    const val SAMPLE_RATE = 16_000
     private const val ASSET_MODEL_DIR = "vosk-fr"   // dossier sous app/src/main/assets/
     private const val LOCAL_MODEL_DIR = "vosk-fr"   // dossier sous filesDir
     private const val SENTINEL = ".ok"
@@ -45,7 +47,7 @@ object VoskTranscriber {
     fun transcribe(ctx: Context, wavFile: File): String {
         val model = ensureModel(ctx)
         val data = wavFile.readBytes()
-        Recognizer(model, SAMPLE_RATE).use { rec ->
+        Recognizer(model, SAMPLE_RATE.toFloat()).use { rec ->
             rec.acceptWaveForm(data, data.size)
             return extractText(rec.finalResult)
         }
@@ -54,25 +56,46 @@ object VoskTranscriber {
     /** Session streaming (pour alimenter avec des ShortArray 16 kHz mono) */
     fun startStreaming(ctx: Context): StreamingSession {
         val model = ensureModel(ctx)
-        val rec = Recognizer(model, SAMPLE_RATE)
+        val rec = Recognizer(model, SAMPLE_RATE.toFloat())
         return StreamingSession(rec)
     }
 
     class StreamingSession internal constructor(
         private val recognizer: Recognizer
     ) {
+        private val mutex = Mutex()
+
+        /**
+         * Feed a PCM16 little-endian mono buffer to Vosk. The number of bytes
+         * passed to [Recognizer.acceptWaveForm] matches exactly the data length.
+         */
         fun feed(pcm: ShortArray) {
             if (pcm.isEmpty()) return
-            val bb = ByteBuffer.allocate(pcm.size * 2).order(ByteOrder.LITTLE_ENDIAN)
-            for (s in pcm) bb.putShort(s)
-            val bytes = bb.array()
-            recognizer.acceptWaveForm(bytes, bytes.size)
+            val byteCount = pcm.size * 2
+            val bytes = ByteArray(byteCount)
+            var j = 0
+            for (s in pcm) {
+                val v = s.toInt()
+                bytes[j++] = (v and 0xff).toByte()
+                bytes[j++] = ((v ushr 8) and 0xff).toByte()
+            }
+            runBlocking {
+                mutex.withLock {
+                    recognizer.acceptWaveForm(bytes, byteCount)
+                }
+            }
         }
 
-        fun partial(): String = extractText(recognizer.partialResult)
+        fun partial(): String = runBlocking {
+            mutex.withLock { extractText(recognizer.partialResult) }
+        }
 
-        fun finish(): String = extractText(recognizer.finalResult).also {
-            recognizer.close()
+        fun finish(): String = runBlocking {
+            mutex.withLock {
+                val text = extractText(recognizer.finalResult)
+                recognizer.close()
+                text
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Ensure microphone recording uses 16 kHz mono PCM to match Vosk
- Serialize Vosk audio feed with a mutex and send exact byte counts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cb661bd4832dbec436d64323f959