### PR TITLE
Handle final transcription text on segment stop

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MicBarController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicBarController.kt
@@ -179,6 +179,13 @@ class MicBarController(
                 if (!wavPath.isNullOrBlank() && nid != null) {
                     withContext(Dispatchers.IO) { repo.updateAudio(nid, wavPath) }
                 }
+                if (finalText.isNotBlank()) {
+                    withContext(Dispatchers.Main) {
+                        onReplaceFinal(finalText, addNewline = !lastWasHandsFree)
+                        if (state == RecordingState.IDLE) binding.liveTranscriptionBar.isGone = true
+                    }
+                    if (nid != null) withContext(Dispatchers.IO) { repo.setBody(nid, finalText) }
+                }
                 if (finalText.isBlank()) {
                     if (!lastWasHandsFree) {
                         val current = binding.txtBodyDetail.text?.toString().orEmpty()


### PR DESCRIPTION
## Summary
- Update `stopSegment` to persist and display final transcription when available
- Hide live transcription bar after committing the final text

## Testing
- `bash ./gradlew test` *(fails: unresolved dependencies / environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c2daf0b8ac832d97d2a2565e43fece