### PR TITLE
Update note body updates to refresh timestamps

### DIFF
--- a/app/src/main/java/com/example/openeer/audio/RecorderService.kt
+++ b/app/src/main/java/com/example/openeer/audio/RecorderService.kt
@@ -93,7 +93,7 @@ class RecorderService : Service() {
                     VoskTranscriber.transcribe(this@RecorderService, File(wav))
                 }.getOrNull()
                 if (!text.isNullOrBlank()) {
-                    runCatching { repo.setBody(noteId, text) }
+                    runCatching { repo.setBody(noteId, text, System.currentTimeMillis()) }
                 }
             }
 

--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -21,8 +21,8 @@ interface NoteDao {
     @Query("UPDATE notes SET audioPath = :path, updatedAt = :updatedAt WHERE id = :id")
     suspend fun updateAudioPath(id: Long, path: String, updatedAt: Long)
 
-    @Query("UPDATE notes SET body = :body WHERE id = :id")
-    suspend fun updateBody(id: Long, body: String)
+    @Query("UPDATE notes SET body = :body, updatedAt = :updatedAt WHERE id = :id")
+    suspend fun updateBody(id: Long, body: String, updatedAt: Long)
 
     @Update
     suspend fun update(note: Note)

--- a/app/src/main/java/com/example/openeer/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteRepository.kt
@@ -37,7 +37,8 @@ class NoteRepository(private val dao: NoteDao) {
         dao.updateLocation(id, lat, lon, place, accuracyM, System.currentTimeMillis())
     }
 
-    suspend fun setBody(id: Long, body: String) = dao.updateBody(id, body)
+    suspend fun setBody(id: Long, body: String, updatedAt: Long) =
+        dao.updateBody(id, body, updatedAt)
 
     suspend fun createTextNote(
         body: String,

--- a/app/src/main/java/com/example/openeer/ui/MicBarController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicBarController.kt
@@ -113,7 +113,9 @@ class MicBarController(
                         binding.liveTranscriptionText.text = event.text
                         val nid = getOpenNoteId()
                         if (nid != null) {
-                            activity.lifecycleScope.launch(Dispatchers.IO) { repo.setBody(nid, display) }
+                            activity.lifecycleScope.launch(Dispatchers.IO) {
+                                repo.setBody(nid, display, System.currentTimeMillis())
+                            }
                         }
                     }
                     is LiveTranscriber.TranscriptionEvent.Final -> {
@@ -131,7 +133,9 @@ class MicBarController(
                         }
                         val nid = getOpenNoteId()
                         if (nid != null) {
-                            activity.lifecycleScope.launch(Dispatchers.IO) { repo.setBody(nid, finalJoined) }
+                            activity.lifecycleScope.launch(Dispatchers.IO) {
+                                repo.setBody(nid, finalJoined, System.currentTimeMillis())
+                            }
                         }
                     }
                 }
@@ -184,7 +188,9 @@ class MicBarController(
                         val current = binding.txtBodyDetail.text?.toString().orEmpty()
                         val text = current + if (current.endsWith("\n")) "" else "\n"
                         withContext(Dispatchers.Main) { onReplaceFinal(text, false) }
-                        if (nid != null) withContext(Dispatchers.IO) { repo.setBody(nid, text) }
+                        if (nid != null) withContext(Dispatchers.IO) {
+                            repo.setBody(nid, text, System.currentTimeMillis())
+                        }
                     }
                     withContext(Dispatchers.Main) { binding.liveTranscriptionBar.isGone = true }
                 }

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -78,7 +78,7 @@ class NotePanelController(
         binding.txtBodyDetail.text = displayBody
         val nid = openNoteId ?: return
         activity.lifecycleScope.launch(Dispatchers.IO) {
-            repo.setBody(nid, displayBody)
+            repo.setBody(nid, displayBody, System.currentTimeMillis())
         }
     }
 
@@ -91,7 +91,9 @@ class NotePanelController(
         val text = if (addNewline) finalBody + "\n" else finalBody
         binding.txtBodyDetail.text = text
         val nid = openNoteId ?: return
-        activity.lifecycleScope.launch(Dispatchers.IO) { repo.setBody(nid, text) }
+        activity.lifecycleScope.launch(Dispatchers.IO) {
+            repo.setBody(nid, text, System.currentTimeMillis())
+        }
     }
 
     // ---- Internes ----


### PR DESCRIPTION
## Summary
- Include updatedAt field when updating note body in NoteDao
- Require timestamp in NoteRepository.setBody and forward to DAO
- Pass current time when updating note body from controllers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2daf34234832d885cc6a29ebf4591