### PR TITLE
Fix text append flow for transcriptions

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MicBarController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicBarController.kt
@@ -32,9 +32,6 @@ class MicBarController(
     private var switchedToHandsFree = false
     private var movedTooMuch = false
 
-    // Concat de segment
-    private var segmentBaseBody: String = ""
-
     // Transcription live
     private var live: LiveTranscriber? = null
     private var lastWasHandsFree = false
@@ -92,9 +89,6 @@ class MicBarController(
         recorder?.start()
         Log.d("MicCtl", "Recorder.start()")
 
-        // Snapshot du corps depuis l’UI
-        segmentBaseBody = binding.txtBodyDetail.text?.toString().orEmpty()
-
         binding.labelMic.text = "Enregistrement (PTT)…"
         binding.iconMic.alpha = 1f
         binding.txtActivity.text = "REC (PTT) • relâchez pour arrêter"
@@ -105,29 +99,15 @@ class MicBarController(
             onEvent = { event ->
                 when (event) {
                     is LiveTranscriber.TranscriptionEvent.Partial -> {
-                        val base = segmentBaseBody
-                        val sep = if (base.isBlank()) "" else " "
-                        val display = base + sep + event.text
-                        // MAJ affichage uniquement (pas d'écriture DB sur les partiels)
-                        onAppendLive(display)
+                        binding.liveTranscriptionBar.isVisible = true
                         binding.liveTranscriptionText.text = event.text
                     }
                     is LiveTranscriber.TranscriptionEvent.Final -> {
-                        val base = segmentBaseBody
-                        val sep = if (base.isBlank()) "" else " "
-                        val finalJoined = (base + sep + event.text).trimEnd() +
-                                if (!lastWasHandsFree) "\n" else ""
-
-                        // Sauvegarde en base (thread IO)
-                        val nid = getOpenNoteId()
-                        if (nid != null) {
-                            activity.lifecycleScope.launch(Dispatchers.IO) {
-                                repo.setBody(nid, finalJoined)
-                            }
-                        }
+                        var segment = event.text.trim()
+                        if (!lastWasHandsFree) segment += "\n"
 
                         activity.lifecycleScope.launch(Dispatchers.Main) {
-                            onReplaceFinal(finalJoined, false)
+                            onReplaceFinal(segment, false)
                             binding.liveTranscriptionText.text = event.text
                             Toast.makeText(activity, "Segment ajouté", Toast.LENGTH_SHORT).show()
                             delay(1500)
@@ -174,7 +154,7 @@ class MicBarController(
                     rec?.stop()
                     rec?.finalizeToWav()
                 }
-                val finalText = withContext(Dispatchers.IO) { live?.stop().orEmpty() }
+                val finalText = withContext(Dispatchers.IO) { live?.stop().orEmpty().trim() }
                 live = null
 
                 val nid = getOpenNoteId()
@@ -182,21 +162,15 @@ class MicBarController(
                     withContext(Dispatchers.IO) { repo.updateAudio(nid, wavPath) }
                 }
 
-                if (finalText.isNotBlank()) {
+                var segment = finalText
+                if (!lastWasHandsFree) segment += "\n"
+
+                if (segment.isNotEmpty()) {
                     withContext(Dispatchers.Main) {
-                        onReplaceFinal(finalText, addNewline = !lastWasHandsFree)
+                        onReplaceFinal(segment, false)
                         if (state == RecordingState.IDLE) binding.liveTranscriptionBar.isGone = true
                     }
-                    if (nid != null) withContext(Dispatchers.IO) { repo.setBody(nid, finalText) }
-                }
-
-                if (finalText.isBlank()) {
-                    if (!lastWasHandsFree) {
-                        val current = binding.txtBodyDetail.text?.toString().orEmpty()
-                        val text = current + if (current.endsWith("\n")) "" else "\n"
-                        withContext(Dispatchers.Main) { onReplaceFinal(text, false) }
-                        if (nid != null) withContext(Dispatchers.IO) { repo.setBody(nid, text) }
-                    }
+                } else {
                     withContext(Dispatchers.Main) { binding.liveTranscriptionBar.isGone = true }
                 }
             } catch (_: Throwable) {

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -82,11 +82,13 @@ class NotePanelController(
      * Ici on met à jour l'UI *et* la base (avec updatedAt géré par le repo).
      */
     fun onReplaceFinal(finalBody: String, addNewline: Boolean) {
-        val text = if (addNewline) finalBody + "\n" else finalBody
-        binding.txtBodyDetail.text = text
+        val toAppend = if (addNewline) finalBody + "\n" else finalBody
+        val current = binding.txtBodyDetail.text?.toString().orEmpty()
+        val newText = current + toAppend
+        binding.txtBodyDetail.text = newText
         val nid = openNoteId ?: return
         activity.lifecycleScope.launch(Dispatchers.IO) {
-            repo.setBody(nid, text) // le repo met à jour updatedAt
+            repo.setBody(nid, newText) // le repo met à jour updatedAt
         }
     }
 


### PR DESCRIPTION
## Summary
- show live partial text only in mic bar without touching note body
- append final transcript segments to note and save once per segment

## Testing
- `bash gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ea630ef8832d89159ee31ef2b589