### PR TITLE
feat: add blocks table

### DIFF
--- a/app/src/main/java/com/example/openeer/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/openeer/data/AppDatabase.kt
@@ -1,20 +1,23 @@
 package com.example.openeer.data
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room.*
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.example.openeer.data.block.BlockDao
+import com.example.openeer.data.block.BlockEntity
+import com.example.openeer.data.db.Converters
 
 @Database(
-    entities = [Note::class, Attachment::class],
-    version = 3,
+    entities = [Note::class, Attachment::class, BlockEntity::class],
+    version = 4,
     exportSchema = false
 )
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun noteDao(): NoteDao
     abstract fun attachmentDao(): AttachmentDao
+    abstract fun blockDao(): BlockDao
 
     companion object {
         @Volatile private var INSTANCE: AppDatabase? = null
@@ -34,6 +37,37 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("""
+                    CREATE TABLE IF NOT EXISTS blocks (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        noteId INTEGER NOT NULL,
+                        type TEXT NOT NULL,
+                        position INTEGER NOT NULL,
+                        groupId TEXT,
+                        text TEXT,
+                        mediaUri TEXT,
+                        mimeType TEXT,
+                        durationMs INTEGER,
+                        width INTEGER,
+                        height INTEGER,
+                        lat REAL,
+                        lon REAL,
+                        placeName TEXT,
+                        routeJson TEXT,
+                        extra TEXT,
+                        createdAt INTEGER NOT NULL,
+                        updatedAt INTEGER NOT NULL,
+                        FOREIGN KEY(noteId) REFERENCES notes(id) ON DELETE CASCADE
+                    )
+                """.trimIndent())
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_blocks_noteId ON blocks(noteId)")
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_blocks_noteId_position ON blocks(noteId, position)")
+                db.execSQL("CREATE INDEX IF NOT EXISTS index_blocks_groupId ON blocks(groupId)")
+            }
+        }
+
         fun get(context: Context): AppDatabase =
             INSTANCE ?: synchronized(this) {
                 INSTANCE ?: Room.databaseBuilder(
@@ -41,7 +75,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "openEER.db"
                 )
-                    .addMigrations(MIGRATION_2_3)
+                    .addMigrations(MIGRATION_2_3, MIGRATION_3_4)
                     // ⚠️ on évite fallbackToDestructiveMigration pour ne pas perdre les données
                     .build()
                     .also { INSTANCE = it }

--- a/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
@@ -1,0 +1,44 @@
+package com.example.openeer.data.block
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BlockDao {
+    @Insert
+    suspend fun insert(block: BlockEntity): Long
+
+    @Insert
+    suspend fun insertAll(blocks: List<BlockEntity>): List<Long>
+
+    @Update
+    suspend fun update(block: BlockEntity)
+
+    @Delete
+    suspend fun delete(block: BlockEntity)
+
+    @Query("SELECT * FROM blocks WHERE noteId = :noteId ORDER BY position ASC")
+    fun observeBlocks(noteId: Long): Flow<List<BlockEntity>>
+
+    @Query("SELECT * FROM blocks WHERE id = :id LIMIT 1")
+    suspend fun getById(id: Long): BlockEntity?
+
+    @Query("SELECT MAX(position) FROM blocks WHERE noteId = :noteId")
+    suspend fun getMaxPosition(noteId: Long): Int?
+
+    @Query("UPDATE blocks SET position = :position WHERE id = :id AND noteId = :noteId")
+    suspend fun updatePosition(id: Long, noteId: Long, position: Int)
+
+    @Transaction
+    suspend fun insertAtEnd(noteId: Long, template: BlockEntity): Long {
+        val pos = (getMaxPosition(noteId) ?: -1) + 1
+        return insert(template.copy(noteId = noteId, position = pos))
+    }
+
+    @Transaction
+    suspend fun reorder(noteId: Long, orderedBlockIds: List<Long>) {
+        orderedBlockIds.forEachIndexed { index, blockId ->
+            updatePosition(blockId, noteId, index)
+        }
+    }
+}

--- a/app/src/main/java/com/example/openeer/data/block/BlockEntity.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockEntity.kt
@@ -1,0 +1,41 @@
+package com.example.openeer.data.block
+
+import androidx.room.*
+import com.example.openeer.data.Note
+
+@Entity(
+    tableName = "blocks",
+    foreignKeys = [
+        ForeignKey(
+            entity = Note::class,
+            parentColumns = ["id"],
+            childColumns = ["noteId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [
+        Index(value = ["noteId"]),
+        Index(value = ["noteId", "position"], unique = true),
+        Index(value = ["groupId"])
+    ]
+)
+data class BlockEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    val noteId: Long,
+    val type: BlockType,
+    val position: Int,
+    val groupId: String? = null,
+    val text: String? = null,
+    val mediaUri: String? = null,
+    val mimeType: String? = null,
+    val durationMs: Long? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+    val lat: Double? = null,
+    val lon: Double? = null,
+    val placeName: String? = null,
+    val routeJson: String? = null,
+    val extra: String? = null,
+    val createdAt: Long,
+    val updatedAt: Long
+)

--- a/app/src/main/java/com/example/openeer/data/block/BlockType.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockType.kt
@@ -1,0 +1,3 @@
+package com.example.openeer.data.block
+
+enum class BlockType { TEXT, PHOTO, VIDEO, AUDIO, SKETCH, LOCATION, ROUTE, FILE }

--- a/app/src/main/java/com/example/openeer/data/block/NoteWithBlocks.kt
+++ b/app/src/main/java/com/example/openeer/data/block/NoteWithBlocks.kt
@@ -1,0 +1,14 @@
+package com.example.openeer.data.block
+
+import androidx.room.Embedded
+import androidx.room.Relation
+import com.example.openeer.data.Note
+
+data class NoteWithBlocks(
+    @Embedded val note: Note,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "noteId"
+    )
+    val blocks: List<BlockEntity>
+)

--- a/app/src/main/java/com/example/openeer/data/db/Converters.kt
+++ b/app/src/main/java/com/example/openeer/data/db/Converters.kt
@@ -1,0 +1,12 @@
+package com.example.openeer.data.db
+
+import androidx.room.TypeConverter
+import com.example.openeer.data.block.BlockType
+
+class Converters {
+    @TypeConverter
+    fun fromBlockType(value: BlockType?): String? = value?.name
+
+    @TypeConverter
+    fun toBlockType(value: String?): BlockType? = value?.let { BlockType.valueOf(it) }
+}


### PR DESCRIPTION
## Summary
- add BlockEntity and BlockDao for note content blocks
- convert BlockType via Room converters and register in AppDatabase
- migrate database to version 4 with new blocks table

## Testing
- no local testing; GitHub Actions will run build, androidTest and lint

## How to test
- Rely on GitHub Actions workflows (Android CI, Android Instrumented Tests, Android Lint)
- Run the app on an existing database to verify migration
- Create an audio note and photo note; behavior should be unchanged
- Check that `blocks` table exists (can be empty)


------
https://chatgpt.com/codex/tasks/task_e_68c41570658c832db022affd9b4978f5