### PR TITLE
Unify keyboard capture with inline note editing

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -171,9 +171,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         // Note panel controller (panneau "note ouverte")
-        notePanel = NotePanelController(this, b) { nid, blockId ->
-            launchKeyboardCapture(nid, blockId)
-        }
+        notePanel = NotePanelController(this, b)
 
         // Mic controller (push-to-talk + mains libres)
         micCtl = MicBarController(
@@ -234,15 +232,8 @@ class MainActivity : AppCompatActivity() {
         // Boutons bas
         b.btnKeyboard.setOnClickListener {
             lifecycleScope.launch {
-                if (notePanel.openNoteId == null) {
-                    val newId = withContext(Dispatchers.IO) { repo.createTextNote("") }
-                    notePanel.open(newId)
-                    launchKeyboardCapture(newId, null)
-                } else {
-                    val nid = notePanel.openNoteId!!
-                    val bid = withContext(Dispatchers.IO) { blocksRepo.createTextBlock(nid) }
-                    launchKeyboardCapture(nid, bid)
-                }
+                val nid = ensureOpenNote()
+                launchKeyboardCapture(nid, null)
             }
         }
         b.btnPhoto.setOnClickListener {

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import android.content.Intent
+import com.example.openeer.ui.editor.NoteEditorActivity
 import java.io.File
 
 /**
@@ -35,7 +36,6 @@ import java.io.File
 class NotePanelController(
     private val activity: AppCompatActivity,
     private val binding: ActivityMainBinding,
-    private val startKeyboard: (Long, Long?) -> Unit
 ) {
     private val repo: NoteRepository by lazy {
         val db = AppDatabase.get(activity)
@@ -104,7 +104,12 @@ class NotePanelController(
             activity.lifecycleScope.launch {
                 val blocks = blocksRepo.observeBlocks(nid).first()
                 val block = blocks.firstOrNull { it.type == BlockType.TEXT }
-                block?.let { startKeyboard(nid, it.id) }
+                val i = Intent(activity, NoteEditorActivity::class.java).apply {
+                    putExtra("noteId", nid)
+                    putExtra("focusLast", false)
+                    block?.let { putExtra("focusBlockId", it.id) }
+                }
+                activity.startActivity(i)
             }
         }
     }

--- a/app/src/main/java/com/example/openeer/ui/editor/NoteEditorActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/editor/NoteEditorActivity.kt
@@ -42,6 +42,7 @@ class NoteEditorActivity : AppCompatActivity() {
 
         noteId = intent.getLongExtra("noteId", 0L)
         focusLast = intent.getBooleanExtra("focusLast", false)
+        pendingFocusId = intent.getLongExtra("focusBlockId", -1L).takeIf { it > 0 }
 
         val adapter = BlocksAdapter(
             onTextCommit = { id, text ->

--- a/app/src/main/java/com/example/openeer/ui/util/ImeInsets.kt
+++ b/app/src/main/java/com/example/openeer/ui/util/ImeInsets.kt
@@ -1,0 +1,40 @@
+package com.example.openeer.ui.util
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+
+/**
+ * Helper to keep a view above the IME and report visibility changes.
+ */
+object ImeInsets {
+    fun apply(root: View, target: View, onVisible: ((Boolean) -> Unit)? = null) {
+        val update: (WindowInsetsCompat) -> Unit = { insets ->
+            val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
+            target.translationY = -imeHeight.toFloat()
+            val visible = imeHeight > 0
+            target.isVisible = visible
+            onVisible?.invoke(visible)
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(root) { _, insets ->
+            update(insets)
+            insets
+        }
+        ViewCompat.setWindowInsetsAnimationCallback(
+            root,
+            object : WindowInsetsAnimationCompat.Callback(
+                WindowInsetsAnimationCompat.Callback.DISPATCH_MODE_CONTINUE_ON_SUBTREE
+            ) {
+                override fun onProgress(
+                    insets: WindowInsetsCompat,
+                    runningAnimations: MutableList<WindowInsetsAnimationCompat>
+                ): WindowInsetsCompat {
+                    update(insets)
+                    return insets
+                }
+            }
+        )
+    }
+}

--- a/app/src/main/res/layout/activity_keyboard_capture.xml
+++ b/app/src/main/res/layout/activity_keyboard_capture.xml
@@ -3,29 +3,29 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#333333">
-
-    <com.example.openeer.ui.sketch.SketchView
-        android:id="@+id/sketchView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/transparent" />
+    android:background="#333333"
+    android:fitsSystemWindows="false">
 
     <EditText
         android:id="@+id/editText"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="bottom"
+        android:layout_height="match_parent"
         android:imeOptions="actionDone"
         android:inputType="textMultiLine"
-        android:maxLines="6"
         android:gravity="top|start"
         android:background="@android:color/transparent"
         android:textColor="#FFFFFF"
         android:padding="8dp" />
 
+    <com.example.openeer.ui.sketch.SketchView
+        android:id="@+id/sketchView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent"
+        android:visibility="gone" />
+
     <LinearLayout
-        android:id="@+id/toolBar"
+        android:id="@+id/toolStrip"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:layout_gravity="bottom"
@@ -80,14 +80,6 @@
             android:background="@android:color/transparent"
             android:contentDescription="@string/action_validate"
             android:src="@drawable/ic_check" />
-
-        <ImageButton
-            android:id="@+id/btnCancel"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="@string/action_cancel"
-            android:src="@drawable/ic_close" />
 
     </LinearLayout>
 

--- a/app/src/test/java/com/example/openeer/ui/sketch/SketchViewTest.kt
+++ b/app/src/test/java/com/example/openeer/ui/sketch/SketchViewTest.kt
@@ -1,0 +1,27 @@
+package com.example.openeer.ui.sketch
+
+import android.content.Context
+import android.view.MotionEvent
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SketchViewTest {
+    @Test
+    fun hasContentAfterStroke() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        val view = SketchView(ctx)
+        assertFalse(view.hasContent())
+        view.setMode(SketchView.Mode.PEN)
+        val down = MotionEvent.obtain(0,0,MotionEvent.ACTION_DOWN,0f,0f,0)
+        val move = MotionEvent.obtain(0,10,MotionEvent.ACTION_MOVE,10f,10f,0)
+        val up = MotionEvent.obtain(0,20,MotionEvent.ACTION_UP,20f,20f,0)
+        view.onTouchEvent(down)
+        view.onTouchEvent(move)
+        view.onTouchEvent(up)
+        assertTrue(view.hasContent())
+    }
+}


### PR DESCRIPTION
## Summary
- show a drawing tool strip above the IME in keyboard capture
- redirect note body taps to inline NoteEditorActivity
- basic SketchView.hasContent unit test

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cad658b0832d804d334bd2e894de