### PR TITLE
feat: add keyboard sketch toolbar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,7 +54,7 @@
             android:exported="false"
             android:screenOrientation="portrait"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar"
-            android:windowSoftInputMode="stateVisible|adjustResize"/>
+            android:windowSoftInputMode="adjustResize"/>
 
 
         <service

--- a/app/src/main/java/com/example/openeer/ui/KeyboardCaptureActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/KeyboardCaptureActivity.kt
@@ -61,17 +61,13 @@ class KeyboardCaptureActivity : AppCompatActivity() {
             }
         }
 
-        ImeInsets.apply(binding.root, binding.toolStrip) { visible -> imeVisible = visible }
+        ImeInsets.apply(binding.root, binding.drawToolbar) { visible -> imeVisible = visible }
 
-        binding.btnPen.setOnClickListener {
+        binding.btnToolPen.setOnClickListener {
             binding.sketchView.setMode(SketchView.Mode.PEN)
             binding.sketchView.isVisible = true
         }
-        binding.btnLine.setOnClickListener {
-            binding.sketchView.setMode(SketchView.Mode.LINE)
-            binding.sketchView.isVisible = true
-        }
-        binding.btnShape.setOnClickListener {
+        binding.btnToolShape.setOnClickListener {
             currentShape = when (currentShape) {
                 SketchView.Mode.RECT -> SketchView.Mode.CIRCLE
                 SketchView.Mode.CIRCLE -> SketchView.Mode.ARROW
@@ -80,12 +76,13 @@ class KeyboardCaptureActivity : AppCompatActivity() {
             binding.sketchView.setMode(currentShape)
             binding.sketchView.isVisible = true
         }
-        binding.btnEraser.setOnClickListener {
+        binding.btnToolEraser.setOnClickListener {
             binding.sketchView.setMode(SketchView.Mode.ERASE)
             binding.sketchView.isVisible = true
         }
-        binding.btnUndo.setOnClickListener { binding.sketchView.undo() }
-        binding.btnOk.setOnClickListener { saveAndFinish() }
+        binding.btnToolUndo.setOnClickListener { binding.sketchView.undo() }
+        binding.btnValidate.setOnClickListener { saveAndFinish() }
+        binding.btnClose.setOnClickListener { finish() }
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/example/openeer/ui/util/ImeInsets.kt
+++ b/app/src/main/java/com/example/openeer/ui/util/ImeInsets.kt
@@ -5,6 +5,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 
 /**
  * Helper to keep a view above the IME and report visibility changes.
@@ -13,7 +14,7 @@ object ImeInsets {
     fun apply(root: View, target: View, onVisible: ((Boolean) -> Unit)? = null) {
         val update: (WindowInsetsCompat) -> Unit = { insets ->
             val imeHeight = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom
-            target.translationY = -imeHeight.toFloat()
+            target.updatePadding(bottom = imeHeight)
             val visible = imeHeight > 0
             target.isVisible = visible
             onVisible?.invoke(visible)

--- a/app/src/main/res/layout/activity_keyboard_capture.xml
+++ b/app/src/main/res/layout/activity_keyboard_capture.xml
@@ -6,6 +6,13 @@
     android:background="#333333"
     android:fitsSystemWindows="false">
 
+    <com.example.openeer.ui.sketch.SketchView
+        android:id="@+id/sketchView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/transparent"
+        android:visibility="gone" />
+
     <EditText
         android:id="@+id/editText"
         android:layout_width="match_parent"
@@ -17,15 +24,8 @@
         android:textColor="#FFFFFF"
         android:padding="8dp" />
 
-    <com.example.openeer.ui.sketch.SketchView
-        android:id="@+id/sketchView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/transparent"
-        android:visibility="gone" />
-
     <LinearLayout
-        android:id="@+id/toolStrip"
+        android:id="@+id/drawToolbar"
         android:layout_width="match_parent"
         android:layout_height="48dp"
         android:layout_gravity="bottom"
@@ -34,7 +34,7 @@
         android:visibility="gone">
 
         <ImageButton
-            android:id="@+id/btnPen"
+            android:id="@+id/btnToolPen"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@android:color/transparent"
@@ -42,15 +42,7 @@
             android:src="@drawable/ic_tool_pen" />
 
         <ImageButton
-            android:id="@+id/btnLine"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Line"
-            android:src="@drawable/ic_tool_line" />
-
-        <ImageButton
-            android:id="@+id/btnShape"
+            android:id="@+id/btnToolShape"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@android:color/transparent"
@@ -58,7 +50,7 @@
             android:src="@drawable/ic_tool_shapes" />
 
         <ImageButton
-            android:id="@+id/btnEraser"
+            android:id="@+id/btnToolEraser"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@android:color/transparent"
@@ -66,7 +58,7 @@
             android:src="@drawable/ic_tool_eraser" />
 
         <ImageButton
-            android:id="@+id/btnUndo"
+            android:id="@+id/btnToolUndo"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@android:color/transparent"
@@ -74,12 +66,20 @@
             android:src="@drawable/ic_tool_undo" />
 
         <ImageButton
-            android:id="@+id/btnOk"
+            android:id="@+id/btnValidate"
             android:layout_width="40dp"
             android:layout_height="40dp"
             android:background="@android:color/transparent"
             android:contentDescription="@string/action_validate"
             android:src="@drawable/ic_check" />
+
+        <ImageButton
+            android:id="@+id/btnClose"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="@android:color/transparent"
+            android:contentDescription="Close"
+            android:src="@drawable/ic_close" />
 
     </LinearLayout>
 


### PR DESCRIPTION
## Summary
- show drawing toolbar above IME in keyboard capture
- wire up sketch tools and close/validate actions
- keep toolbar visible only when keyboard is open

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6466abffc832da60ec8c9470eaacf