### PR TITLE
Feat: Remove inline sketch overlay to restore clean mother-body editing

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/editor/EditorBodyController.kt
+++ b/app/src/main/java/com/example/openeer/ui/editor/EditorBodyController.kt
@@ -1,0 +1,172 @@
+package com.example.openeer.ui.editor
+
+import android.content.Context
+import android.graphics.Rect
+import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.isVisible
+import androidx.lifecycle.lifecycleScope
+import com.example.openeer.data.NoteRepository
+import com.example.openeer.databinding.ActivityMainBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class EditorBodyController(
+    private val activity: AppCompatActivity,
+    private val binding: ActivityMainBinding,
+    private val repo: NoteRepository,
+    private val onEditModeChanged: (Boolean) -> Unit = {}
+) {
+
+    private var editOverlay: EditText? = null
+    private var keyboardVisible = false
+    private var editUiActive = false
+    private var editingNoteId: Long? = null
+
+    init {
+        wireKeyboardListener()
+    }
+
+    fun enterInlineEdit(noteId: Long?) {
+        val id = noteId ?: return
+        editingNoteId = id
+        val overlay = editOverlay ?: createOverlay()
+        val currentDisplayed = binding.txtBodyDetail.text?.toString().orEmpty()
+        val initialText = if (currentDisplayed.trim() == PLACEHOLDER) "" else currentDisplayed
+        if (overlay.text?.toString() != initialText) {
+            overlay.setText(initialText)
+        }
+        overlay.setSelection(overlay.text?.length ?: 0)
+        overlay.isVisible = true
+        binding.txtBodyDetail.isVisible = false
+        overlay.post {
+            overlay.requestFocus()
+            showIme(overlay)
+        }
+        updateEditUi(true)
+        binding.scrollBody.requestDisallowInterceptTouchEvent(true)
+    }
+
+    fun commitInlineEdit(noteId: Long?) {
+        val overlay = editOverlay ?: run {
+            exitEditUi()
+            return
+        }
+        val id = noteId ?: editingNoteId ?: return
+        val newText = overlay.text?.toString().orEmpty()
+        binding.txtBodyDetail.text = if (newText.isBlank()) PLACEHOLDER else newText
+        activity.lifecycleScope.launch(Dispatchers.IO) {
+            repo.setBody(id, newText)
+        }
+        editingNoteId = null
+        exitEditUi()
+    }
+
+    fun cancelInlineEdit() {
+        if (editOverlay == null) {
+            exitEditUi()
+            return
+        }
+        editingNoteId = null
+        exitEditUi()
+    }
+
+    fun exitEditUi() {
+        val overlay = editOverlay
+        if (overlay != null) {
+            hideIme(overlay)
+            overlay.isVisible = false
+        }
+        binding.txtBodyDetail.isVisible = true
+        updateEditUi(false)
+        binding.scrollBody.requestDisallowInterceptTouchEvent(false)
+        editingNoteId = null
+    }
+
+    fun showIme(target: View?) {
+        val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        if (target != null) {
+            imm?.showSoftInput(target, InputMethodManager.SHOW_IMPLICIT)
+        }
+    }
+
+    fun hideIme(target: View?) {
+        val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+        val token = target?.windowToken
+        if (token != null) {
+            imm?.hideSoftInputFromWindow(token, 0)
+        }
+    }
+
+    fun isKeyboardVisible(): Boolean = keyboardVisible
+
+    fun activeBodyView(): View = editOverlay?.takeIf { it.isVisible } ?: binding.txtBodyDetail
+
+    private fun createOverlay(): EditText {
+        val overlay = EditText(activity).apply {
+            id = View.generateViewId()
+            layoutParams = ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+            setPadding(
+                binding.txtBodyDetail.paddingLeft,
+                binding.txtBodyDetail.paddingTop,
+                binding.txtBodyDetail.paddingRight,
+                binding.txtBodyDetail.paddingBottom
+            )
+            textSize = binding.txtBodyDetail.textSize / activity.resources.displayMetrics.scaledDensity
+            setBackgroundColor(0x00000000)
+            isSingleLine = false
+            imeOptions = EditorInfo.IME_ACTION_DONE
+            visibility = View.GONE
+            setOnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    commitInlineEdit(editingNoteId)
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+        (binding.noteBodyContainer as? ViewGroup)?.let { container ->
+            val bodyIndex = container.indexOfChild(binding.txtBodyDetail)
+            val insertIndex = if (bodyIndex >= 0) bodyIndex + 1 else container.childCount
+            container.addView(overlay, insertIndex)
+        }
+        editOverlay = overlay
+        return overlay
+    }
+
+    private fun updateEditUi(active: Boolean) {
+        if (editUiActive == active) return
+        editUiActive = active
+        onEditModeChanged(active)
+    }
+
+    private fun wireKeyboardListener() {
+        binding.root.viewTreeObserver.addOnGlobalLayoutListener {
+            val r = Rect()
+            binding.root.getWindowVisibleDisplayFrame(r)
+            val screenHeight = binding.root.rootView.height
+            val keypadHeight = screenHeight - r.bottom
+            val visible = keypadHeight > screenHeight * 0.15
+            if (visible != keyboardVisible) {
+                keyboardVisible = visible
+                if (!visible) {
+                    exitEditUi()
+                } else if (editOverlay?.isVisible == true) {
+                    updateEditUi(true)
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val PLACEHOLDER = "(transcription en cours…)"
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -73,7 +73,7 @@
                 android:focusable="true" />
         </LinearLayout>
 
-        <!-- Corps défilant avec superposition texte + dessin -->
+        <!-- Corps défilant -->
         <ScrollView
             android:id="@+id/scrollBody"
             android:layout_width="match_parent"
@@ -81,8 +81,9 @@
             android:layout_weight="1"
             android:fillViewport="true">
 
-            <FrameLayout
+            <LinearLayout
                 android:id="@+id/noteBodyContainer"
+                android:orientation="vertical"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content">
 
@@ -95,24 +96,8 @@
                     android:layout_height="wrap_content"
                     android:padding="8dp" />
 
-                <!-- Calque dessin -->
-                <com.example.openeer.ui.sketch.SketchView
-    android:id="@+id/sketchOverlay"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@android:color/transparent"
-    android:clickable="true"
-    android:minHeight="48dp"
-    android:focusable="false" />
-
-            </FrameLayout>
+            </LinearLayout>
         </ScrollView>
-
-        <!-- ⬇️ barre d’outils dessin (inclus, masquée par défaut dans son propre layout) -->
-        <include
-            layout="@layout/view_sketch_toolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
 
         <!-- Bouton Lecture audio -->
         <Button


### PR DESCRIPTION
## Summary
- strip the sketch overlay and toolbar include from the main activity layout, leaving a simple vertical body container
- simplify MainActivity to drop sketch UI wiring while still toggling other panels during inline editing
- update EditorBodyController to reuse a hidden EditText inside the body container instead of managing a drawing overlay

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f6d3ffdc832d9f1f6823b79af274