### PR TITLE
Feat: Wire buttons to create child TEXT and SKETCH blocks

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -96,6 +96,16 @@
                     android:layout_height="wrap_content"
                     android:padding="8dp" />
 
+                <LinearLayout
+                    android:id="@+id/childBlocksContainer"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
+                    android:visibility="gone"
+                    android:animateLayoutChanges="true" />
+
             </LinearLayout>
         </ScrollView>
 


### PR DESCRIPTION
## Summary
- launch KeyboardCaptureActivity from the keyboard quick action and handle its result to refresh the open note
- hook the sketch action to SketchCaptureActivity, then focus the new child block with a snackbar
- render child blocks in the note panel so new text/sketch items can be scrolled to and flashed

## Testing
- ./gradlew :app:assembleDebug :app:test *(fails: Android SDK not available in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68c915915874832d940b87f14f35d07b