### PR TITLE
Fix: Repository – no body side-effects when creating child blocks

### DIFF
--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -36,10 +36,7 @@ class BlocksRepository(
             createdAt = now,
             updatedAt = now
         )
-        val id = insert(noteId, block)
-        // ➕ MAJ aperçu pour la liste (sans remplacer la logique blocs côté détail)
-        noteDao?.updateBody(noteId, text.take(300), now)
-        return id
+        return insert(noteId, block)
     }
 
     suspend fun createTextBlock(noteId: Long): Long {
@@ -116,10 +113,7 @@ class BlocksRepository(
             createdAt = now,
             updatedAt = now
         )
-        val id = insert(noteId, block)
-        // ➕ idem : garder un aperçu exploitable dans la liste
-        noteDao?.updateBody(noteId, text.take(300), now)
-        return id
+        return insert(noteId, block)
     }
 
     suspend fun appendLocation(
@@ -187,15 +181,7 @@ class BlocksRepository(
             createdAt = now,
             updatedAt = now
         )
-        val id = insert(noteId, block)
-        // Optionnel : si aucune preview n’existe encore, mettre un libellé
-        noteDao?.let { dao ->
-            val current = dao.getByIdOnce(noteId)
-            if (current != null && current.body.isBlank()) {
-                dao.updateBody(noteId, "[Croquis]", now)
-            }
-        }
-        return id
+        return insert(noteId, block)
     }
 
     suspend fun createSketchBlock(
@@ -237,14 +223,7 @@ class BlocksRepository(
             createdAt = now,
             updatedAt = now
         )
-        val id = insert(noteId, block)
-        noteDao?.let { dao ->
-            val current = dao.getByIdOnce(noteId)
-            if (current != null && current.body.isBlank()) {
-                dao.updateBody(noteId, "[Croquis]", now)
-            }
-        }
-        return id
+        return insert(noteId, block)
     }
 
     suspend fun updateSketchVector(


### PR DESCRIPTION
## Summary
- stop updating the parent note body from BlocksRepository when creating text, transcription, or sketch blocks
- ensure sketch append helpers no longer back-fill "[Croquis]" into the note body

## Testing
- ./gradlew :app:test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9232700a0832d8e63e4a22d99e9e9