### PR TITLE
Fix: Visibility for BlockExtras (public/internal mismatch)

### DIFF
--- a/app/src/main/java/com/example/openeer/data/block/BlockExtras.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockExtras.kt
@@ -1,0 +1,33 @@
+package com.example.openeer.data.block
+
+/**
+ * Strongly typed accessors for optional metadata stored on [BlockEntity].
+ */
+data class BlockExtras(
+    val text: String? = null,
+    val mediaUri: String? = null,
+    val mimeType: String? = null,
+    val durationMs: Long? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+    val lat: Double? = null,
+    val lon: Double? = null,
+    val placeName: String? = null,
+    val routeJson: String? = null,
+    val extra: String? = null,
+)
+
+fun BlockEntity.updateExtras(extras: BlockExtras): BlockEntity =
+    copy(
+        text = extras.text ?: text,
+        mediaUri = extras.mediaUri ?: mediaUri,
+        mimeType = extras.mimeType ?: mimeType,
+        durationMs = extras.durationMs ?: durationMs,
+        width = extras.width ?: width,
+        height = extras.height ?: height,
+        lat = extras.lat ?: lat,
+        lon = extras.lon ?: lon,
+        placeName = extras.placeName ?: placeName,
+        routeJson = extras.routeJson ?: routeJson,
+        extra = extras.extra ?: extra,
+    )


### PR DESCRIPTION
## Summary
- add a typed `BlockExtras` data class in the block data package
- expose the helper as a public data holder so the public `updateExtras` API no longer references an internal type

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92a35078c832d9a61913b93524095