### PR TITLE
Fix: btnPhoto launches photo capture instead of sketch capture

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -173,6 +173,12 @@ class MainActivity : AppCompatActivity() {
         b.btnPhoto.setOnClickListener {
             lifecycleScope.launch {
                 val nid = ensureOpenNote()
+                captureLauncher.launchPhotoCapture(nid)
+            }
+        }
+        b.btnLibrary.setOnClickListener {
+            lifecycleScope.launch {
+                val nid = ensureOpenNote()
                 captureLauncher.launchSketchCapture(nid)
             }
         }

--- a/app/src/main/java/com/example/openeer/ui/capture/CaptureLauncher.kt
+++ b/app/src/main/java/com/example/openeer/ui/capture/CaptureLauncher.kt
@@ -137,6 +137,13 @@ class CaptureLauncher(
         sketchCaptureLauncher.launch(intent)
     }
 
+    fun launchPhotoCapture(noteId: Long) {
+        if (notePanel.openNoteId != noteId) {
+            notePanel.open(noteId)
+        }
+        showPhotoSheet()
+    }
+
     fun launchTakePhoto() {
         openCamera()
     }


### PR DESCRIPTION
## Summary
- wire the photo action to the dedicated photo capture flow
- hook the palette button up to the sketch capture launcher
- expose a `launchPhotoCapture` entry point on `CaptureLauncher`

## Testing
- ./gradlew :app:assembleDebug :app:test *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c943dce048832d9ec7edbcd19d958e