### PR TITLE
Feat: Bottom bar completed to 7 buttons + Library returns to main list + Sketch/Map wiring

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -176,11 +176,19 @@ class MainActivity : AppCompatActivity() {
                 captureLauncher.launchPhotoCapture(nid)
             }
         }
-        b.btnLibrary.setOnClickListener {
+        b.btnSketch.setOnClickListener {
             lifecycleScope.launch {
                 val nid = ensureOpenNote()
                 captureLauncher.launchSketchCapture(nid)
             }
+        }
+        b.btnLibrary.setOnClickListener {
+            editorBody.commitInlineEdit(notePanel.openNoteId)
+            notePanel.close()
+            b.recycler.post { b.recycler.requestFocus() }
+        }
+        b.btnMap.setOnClickListener {
+            b.root.snackbar("Carte/Itinéraire — bientôt disponible")
         }
 
         // Clic sur le corps = édition inline

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -222,6 +222,25 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
         <LinearLayout
+            android:id="@+id/btnSketch"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent">
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@drawable/ic_tool_pen"
+                android:contentDescription="Dessin" />
+            <TextView
+                android:text="Dessin"
+                android:textSize="12sp"
+                android:layout_marginTop="4dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+        <LinearLayout
             android:id="@+id/btnLibrary"
             android:orientation="vertical"
             android:gravity="center"
@@ -235,6 +254,25 @@
                 android:contentDescription="Bibliothèque" />
             <TextView
                 android:text="Bibliothèque"
+                android:textSize="12sp"
+                android:layout_marginTop="4dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+        <LinearLayout
+            android:id="@+id/btnMap"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent">
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@android:drawable/ic_dialog_map"
+                android:contentDescription="Carte" />
+            <TextView
+                android:text="Carte"
                 android:textSize="12sp"
                 android:layout_marginTop="4dp"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary
- expand the bottom action bar layout with dedicated sketch and map entries alongside the existing buttons
- wire the new sketch button to launch sketch capture, provide a snackbar stub for the map button, and make the library button return to the main list view

## Testing
- :app:assembleDebug *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c94de25a78832d877eef95c1398164