### PR TITLE
Fix: Keyboard opens inline mother-body editor (same as transcription)

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -160,14 +161,18 @@ class MainActivity : AppCompatActivity() {
         editorBody = EditorBodyController(
             activity = this,
             binding = b,
-            repo = repo
+            repo = repo,
+            onEditModeChanged = { editing ->
+                b.btnMicBar.isVisible = !editing
+                b.bottomBar.isVisible = !editing
+            }
         )
 
         // Boutons barre du bas
         b.btnKeyboard.setOnClickListener {
             lifecycleScope.launch {
-                val nid = ensureOpenNote()
-                captureLauncher.launchKeyboardCapture(nid)
+                ensureOpenNote()
+                editorBody.enterInlineEdit(notePanel.openNoteId)
             }
         }
         b.btnPhoto.setOnClickListener {

--- a/app/src/main/res/layout/activity_keyboard_capture.xml
+++ b/app/src/main/res/layout/activity_keyboard_capture.xml
@@ -6,8 +6,6 @@
     android:background="#333333"
     android:clipToPadding="false">
 
-    
-    <!-- Saisie texte : occupe tout l’écran, reste visible pendant le dessin -->
     <EditText
         android:id="@+id/editText"
         android:layout_width="match_parent"
@@ -19,83 +17,5 @@
         android:padding="12dp"
         android:textColor="@android:color/white"
         android:textSize="18sp" />
-
-<!-- Zone de dessin, cachée tant qu’on ne touche pas aux outils -->
-    <com.example.openeer.ui.sketch.SketchView
-        android:id="@+id/sketchView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@android:color/transparent"
-        android:visibility="gone" />
-
-    <!-- Barre d’outils dessin : ancrée en bas ; visible seulement quand l’IME est ouvert -->
-    <!-- Couleur de debug pour la repérer (#CC9C27FF). Tu pourras l'enlever plus tard. -->
-    <LinearLayout
-        android:id="@+id/drawToolbar"
-        android:layout_width="match_parent"
-        android:layout_height="56dp"
-        android:layout_gravity="bottom"
-        android:orientation="horizontal"
-        android:gravity="center_vertical"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:elevation="12dp"
-        android:background="#CC9C27FF"
-        android:visibility="gone">
-
-        <ImageButton
-            android:id="@+id/btnToolPen"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Stylo"
-            android:src="@drawable/ic_tool_pen" />
-
-        <ImageButton
-            android:id="@+id/btnToolShape"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Formes"
-            android:src="@drawable/ic_tool_shapes" />
-
-        <ImageButton
-            android:id="@+id/btnToolEraser"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Gomme"
-            android:src="@drawable/ic_tool_eraser" />
-
-        <ImageButton
-            android:id="@+id/btnToolUndo"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Annuler"
-            android:src="@drawable/ic_tool_undo" />
-
-        <Space
-            android:layout_width="0dp"
-            android:layout_height="1dp"
-            android:layout_weight="1" />
-
-        <ImageButton
-            android:id="@+id/btnValidate"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Valider"
-            android:src="@drawable/ic_check" />
-
-        <ImageButton
-            android:id="@+id/btnClose"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:background="@android:color/transparent"
-            android:contentDescription="Fermer"
-            android:src="@drawable/ic_close" />
-
-    </LinearLayout>
 
 </FrameLayout>


### PR DESCRIPTION
## Summary
- replace the keyboard capture launch with inline body editing and hide the mic and action bars while editing
- simplify KeyboardCaptureActivity to focus on text input only and drop sketch overlay resources

## Testing
- ./gradlew :app:assembleDebug *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0613f1a8832db1eb7c28165478ab