### PR TITLE
Feat: Bottom media strip (photos + sketches + audio) and remove fallback rectangles

### DIFF
--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -253,4 +253,11 @@ class BlocksRepository(
         }
         return noteId
     }
+
+    suspend fun deleteBlock(blockId: Long) {
+        withContext(io) {
+            val current = blockDao.getById(blockId) ?: return@withContext
+            blockDao.delete(current)
+        }
+    }
 }

--- a/app/src/main/java/com/example/openeer/ui/PhotoViewerActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/PhotoViewerActivity.kt
@@ -1,8 +1,10 @@
 package com.example.openeer.ui
 
+import android.net.Uri
 import android.os.Bundle
 import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.net.toUri
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.request.RequestOptions
@@ -14,17 +16,26 @@ class PhotoViewerActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_photo_viewer)
 
-        val path = intent.getStringExtra("path")
+        val raw = intent.getStringExtra("path")
         val img = findViewById<ImageView>(R.id.photoView)
 
-        if (path.isNullOrBlank() || !File(path).exists()) {
+        val targetUri = when {
+            raw.isNullOrBlank() -> null
+            raw.startsWith("content://") || raw.startsWith("file://") -> Uri.parse(raw)
+            else -> {
+                val file = File(raw)
+                if (file.exists()) file.toUri() else null
+            }
+        }
+
+        if (targetUri == null) {
             finish()
             return
         }
 
         // Glide lit l’EXIF automatiquement -> bonne rotation
         Glide.with(this)
-            .load(File(path))
+            .load(targetUri)
             .apply(
                 RequestOptions()
                     .fitCenter()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -119,11 +119,14 @@
             android:padding="12dp" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/attachmentsStrip"
+            android:id="@+id/mediaStrip"
             android:layout_width="match_parent"
-            android:layout_height="72dp"
-            android:visibility="gone"
-            android:layout_marginTop="8dp" />
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingStart="8dp"
+            android:paddingEnd="8dp"
+            android:paddingBottom="8dp"
+            android:visibility="gone" />
 
         <!-- Métadonnées de la note -->
         <TextView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,11 @@
     <string name="msg_block_text_added">Bloc texte ajouté</string>
     <string name="msg_sketch_added">Croquis ajouté</string>
     <string name="msg_capture_added">Capture ajoutée (%1$d blocs)</string>
+    <string name="media_action_share">Partager</string>
+    <string name="media_action_delete">Supprimer</string>
+    <string name="media_delete_confirm">Supprimer cet élément ?</string>
+    <string name="media_delete_done">Élément supprimé</string>
+    <string name="media_delete_error">Suppression impossible</string>
+    <string name="media_share_error">Partage impossible</string>
+    <string name="media_missing_file">Fichier introuvable</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -14,4 +14,12 @@
     <external-cache-path
         name="images_external_cache"
         path="images/" />
+
+    <!-- Enregistrements audio (wav) -->
+    <files-path
+        name="recordings_files"
+        path="recordings/" />
+    <external-files-path
+        name="recordings_external"
+        path="recordings/" />
 </paths>


### PR DESCRIPTION
## Summary
- replace the note panel attachment strip with a DiffUtil-powered media strip showing photo, sketch, and audio blocks
- support inline media actions (preview, share, delete) including audio playback, duration display, and secure file sharing
- remove generic fallback rectangles, update resources/layouts, and allow the photo viewer to handle content URIs

## Testing
- ./gradlew :app:assembleDebug *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0bbb6508832d8827500cd30eb9e8