### PR TITLE
Fix: Treat LOCATION/ROUTE as note footer metadata (no visual blocks)

### DIFF
--- a/app/src/main/java/com/example/openeer/audio/RecorderService.kt
+++ b/app/src/main/java/com/example/openeer/audio/RecorderService.kt
@@ -39,7 +39,7 @@ class RecorderService : Service() {
         super.onCreate()
         val db = AppDatabase.get(this)
         repo = NoteRepository(db.noteDao(), db.attachmentDao())
-        blocksRepo = BlocksRepository(db.blockDao())
+        blocksRepo = BlocksRepository(db.blockDao(), db.noteDao())
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -58,11 +58,20 @@ class RecorderService : Service() {
         scope.launch {
             val place = runCatching { getOneShotPlace(this@RecorderService) }.getOrNull()
             noteId = repo.createTextNote(
-                body  = "(audio en cours d’enregistrement…)",
-                lat   = place?.lat, lon = place?.lon, place = place?.label
+                body = "(audio en cours d’enregistrement…)",
+                lat = place?.lat,
+                lon = place?.lon,
+                place = place?.label,
+                accuracyM = place?.accuracyM
             )
             if (place != null) {
-                blocksRepo.appendLocation(noteId, place.lat, place.lon, place.label)
+                blocksRepo.appendLocation(
+                    noteId = noteId,
+                    lat = place.lat,
+                    lon = place.lon,
+                    placeName = place.label,
+                    accuracyM = place.accuracyM
+                )
             }
         }
 

--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -120,20 +120,20 @@ class BlocksRepository(
         noteId: Long,
         lat: Double,
         lon: Double,
-        placeName: String? = null
-    ): Long {
-        val now = System.currentTimeMillis()
-        val block = BlockEntity(
-            noteId = noteId,
-            type = BlockType.LOCATION,
-            position = 0,
-            lat = lat,
-            lon = lon,
-            placeName = placeName,
-            createdAt = now,
-            updatedAt = now
-        )
-        return insert(noteId, block)
+        placeName: String? = null,
+        accuracyM: Float? = null
+    ) {
+        val dao = noteDao ?: throw IllegalStateException("noteDao required for location metadata")
+        withContext(io) {
+            dao.updateLocation(
+                id = noteId,
+                lat = lat,
+                lon = lon,
+                place = placeName,
+                accuracyM = accuracyM,
+                updatedAt = System.currentTimeMillis()
+            )
+        }
     }
 
     // ⚠️ FIX: on délègue au DAO (double passe avec positions temporaires uniques)

--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -135,14 +135,13 @@ class MainActivity : AppCompatActivity() {
                             lifecycleScope.launch(Dispatchers.IO) {
                                 val place = runCatching { getOneShotPlace(this@MainActivity) }.getOrNull()
                                 if (place != null) {
-                                    repo.updateLocation(
-                                        id = newId,
+                                    blocksRepo.appendLocation(
+                                        noteId = newId,
                                         lat = place.lat,
                                         lon = place.lon,
-                                        place = place.label,
+                                        placeName = place.label,
                                         accuracyM = place.accuracyM
                                     )
-                                    blocksRepo.appendLocation(newId, place.lat, place.lon, place.label)
                                 }
                             }
                             micCtl.beginPress(initialX = ev.x)
@@ -245,14 +244,13 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch(Dispatchers.IO) {
             val place = runCatching { getOneShotPlace(this@MainActivity) }.getOrNull()
             if (place != null) {
-                repo.updateLocation(
-                    id = newId,
+                blocksRepo.appendLocation(
+                    noteId = newId,
                     lat = place.lat,
                     lon = place.lon,
-                    place = place.label,
+                    placeName = place.label,
                     accuracyM = place.accuracyM
                 )
-                blocksRepo.appendLocation(newId, place.lat, place.lon, place.label)
             }
         }
         return newId

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -174,12 +174,21 @@ class NotePanelController(
     }
 
     private fun renderBlocks(blocks: List<BlockEntity>) {
+        val displayBlocks = blocks.filterNot {
+            it.type == BlockType.LOCATION || it.type == BlockType.ROUTE
+        }
         val container = binding.childBlocksContainer
-        if (blocks.isEmpty()) {
+        if (displayBlocks.isEmpty()) {
             container.isGone = true
             container.removeAllViews()
             blockViews.clear()
             return
+        }
+
+        pendingHighlightBlockId?.let { highlightId ->
+            if (displayBlocks.none { it.id == highlightId }) {
+                pendingHighlightBlockId = null
+            }
         }
 
         container.isVisible = true
@@ -187,7 +196,7 @@ class NotePanelController(
         blockViews.clear()
         val margin = (8 * container.resources.displayMetrics.density).toInt()
 
-        blocks.forEach { block ->
+        displayBlocks.forEach { block ->
             val view = when (block.type) {
                 BlockType.TEXT -> createTextBlockView(block, margin)
                 BlockType.SKETCH, BlockType.PHOTO -> createImageBlockView(block, margin)

--- a/app/src/main/java/com/example/openeer/ui/editor/BlocksAdapter.kt
+++ b/app/src/main/java/com/example/openeer/ui/editor/BlocksAdapter.kt
@@ -41,6 +41,17 @@ class BlocksAdapter(
         else -> TYPE_TEXT
     }
 
+    override fun submitList(list: List<BlockEntity>?) {
+        super.submitList(list?.filterNot(::isMetadataBlock))
+    }
+
+    override fun submitList(list: List<BlockEntity>?, commitCallback: Runnable?) {
+        super.submitList(list?.filterNot(::isMetadataBlock), commitCallback)
+    }
+
+    private fun isMetadataBlock(block: BlockEntity): Boolean =
+        block.type == BlockType.LOCATION || block.type == BlockType.ROUTE
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inf = LayoutInflater.from(parent.context)
         return when (viewType) {


### PR DESCRIPTION
## Summary
- update block filtering so LOCATION/ROUTE blocks are hidden from child lists and adapters
- repurpose BlocksRepository.appendLocation to persist note metadata (lat/lon/place/accuracy) instead of inserting a child block
- adjust location capture flows and tests to rely on the metadata footer

## Testing
- `./gradlew :app:assembleDebug :app:test` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca120d251c832da23a6d97986678cf