### PR TITLE
Refactor scroll highlighting to utility

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/panel/util/ScrollHighlighter.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/util/ScrollHighlighter.kt
@@ -1,0 +1,23 @@
+package com.example.openeer.ui.panel.util
+
+import android.view.View
+import android.widget.ScrollView
+
+class ScrollHighlighter(private val scrollView: ScrollView) {
+
+    fun scrollToAndFlash(view: View) {
+        scrollView.post {
+            val density = view.resources.displayMetrics.density
+            val offset = (16 * density).toInt()
+            val targetY = (view.top - offset).coerceAtLeast(0)
+            scrollView.smoothScrollTo(0, targetY)
+            flashView(view)
+        }
+    }
+
+    private fun flashView(view: View) {
+        view.animate().cancel()
+        view.alpha = 0.5f
+        view.animate().alpha(1f).setDuration(350L).start()
+    }
+}


### PR DESCRIPTION
## Summary
- extract the scroll highlighting behavior into a reusable `ScrollHighlighter`
- use the new helper from `NotePanelController` when scrolling to blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca7495caf8832db931304c8ffe9612