### PR TITLE
Stop creating text blocks from transcription

### DIFF
--- a/app/src/main/java/com/example/openeer/audio/RecorderService.kt
+++ b/app/src/main/java/com/example/openeer/audio/RecorderService.kt
@@ -106,8 +106,8 @@ class RecorderService : Service() {
                 }.getOrNull()
 
                 if (!text.isNullOrBlank()) {
+                    // IMPORTANT: transcription -> Note.body only, no TEXT blocks.
                     runCatching { repo.setBody(noteId, text) }
-                    runCatching { blocksRepo.appendTranscription(noteId, text, gid) }
                 }
             }
 

--- a/app/src/main/java/com/example/openeer/ui/MicBarController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicBarController.kt
@@ -110,6 +110,7 @@ class MicBarController(
                         if (!lastWasHandsFree) segment += "\n"
 
                         activity.lifecycleScope.launch(Dispatchers.Main) {
+                            // IMPORTANT: transcription -> Note.body only, no TEXT blocks.
                             onReplaceFinal(segment, false)
                             binding.liveTranscriptionText.text = event.text
                             Toast.makeText(activity, "Segment ajouté", Toast.LENGTH_SHORT).show()
@@ -166,9 +167,6 @@ class MicBarController(
                     withContext(Dispatchers.IO) {
                         repo.updateAudio(nid, wavPath)
                         blocksRepo.appendAudio(nid, wavPath, null, "audio/wav", gid)
-                        if (finalText.isNotEmpty()) {
-                            blocksRepo.appendTranscription(nid, finalText, gid)
-                        }
                     }
                 }
 
@@ -177,6 +175,7 @@ class MicBarController(
 
                 if (segment.isNotEmpty()) {
                     withContext(Dispatchers.Main) {
+                        // IMPORTANT: transcription -> Note.body only, no TEXT blocks.
                         onReplaceFinal(segment, false)
                         if (state == RecordingState.IDLE) binding.liveTranscriptionBar.isGone = true
                     }


### PR DESCRIPTION
## Summary
- stop creating TEXT blocks when saving audio transcription and rely on Note.body updates
- add prominent inline comments documenting that transcription text must only update the note body

## Testing
- `./gradlew test` *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1a114090832da37e9080b3fae204