### PR TITLE
Stop rendering media blocks in note body

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -188,8 +188,7 @@ class NotePanelController(
             val view = when (block.type) {
                 // On n’affiche plus les blocs TEXT dans le corps : tout le texte vit dans Note.body
                 BlockType.TEXT -> null
-                BlockType.SKETCH, BlockType.PHOTO ->
-                    BlockRenderers.createImageBlockView(container.context, block, margin)
+                BlockType.SKETCH, BlockType.PHOTO -> null
                 BlockType.VIDEO, BlockType.ROUTE, BlockType.FILE ->
                     BlockRenderers.createUnsupportedBlockView(container.context, block, margin)
                 BlockType.AUDIO, BlockType.LOCATION -> null

--- a/app/src/main/java/com/example/openeer/ui/panel/blocks/BlockRenderers.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/blocks/BlockRenderers.kt
@@ -3,45 +3,12 @@ package com.example.openeer.ui.panel.blocks
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
-import com.bumptech.glide.Glide
 import com.example.openeer.data.block.BlockEntity
 import com.google.android.material.card.MaterialCardView
 
 object BlockRenderers {
-    fun createImageBlockView(context: Context, block: BlockEntity, margin: Int): View {
-        val image = ImageView(context).apply {
-            layoutParams = ViewGroup.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            )
-            adjustViewBounds = true
-            scaleType = ImageView.ScaleType.CENTER_CROP
-            contentDescription = block.type.name
-        }
-        val uri = block.mediaUri
-        if (!uri.isNullOrBlank()) {
-            Glide.with(image).load(uri).into(image)
-        } else {
-            image.setImageResource(android.R.drawable.ic_menu_report_image)
-            image.scaleType = ImageView.ScaleType.CENTER_INSIDE
-        }
-
-        return MaterialCardView(context).apply {
-            layoutParams = LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT
-            ).apply { setMargins(0, margin, 0, margin) }
-            radius = 20f
-            cardElevation = 6f
-            useCompatPadding = true
-            tag = block.id
-            addView(image)
-        }
-    }
-
     fun createUnsupportedBlockView(context: Context, block: BlockEntity, margin: Int): View {
         val padding = (16 * context.resources.displayMetrics.density).toInt()
         return MaterialCardView(context).apply {


### PR DESCRIPTION
## Summary
- skip rendering photo and sketch blocks inside the note body container
- remove the obsolete image block renderer now that media is limited to the strip

## Testing
- `./gradlew test` *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb1d0877dc832dbb3c5b9a4a7c7427