### PR TITLE
Open existing post-it on click

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -215,14 +215,11 @@ class NotePanelController(
                 BlockType.AUDIO -> block.mediaUri?.takeIf { it.isNotBlank() }?.let {
                     MediaStripItem.Audio(block.id, it, block.mimeType, block.durationMs)
                 }
-                BlockType.TEXT -> {
-                    val preview = (block.text ?: "")
-                        .lineSequence()
-                        .firstOrNull()
-                        ?.trim()
-                        .orEmpty()
-                    MediaStripItem.Text(block.id, preview)
-                }
+                BlockType.TEXT -> MediaStripItem.Text(
+                    blockId = block.id,
+                    noteId = block.noteId,
+                    content = block.text.orEmpty(),
+                )
                 else -> null
             }
         }

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaActions.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaActions.kt
@@ -13,6 +13,7 @@ import com.example.openeer.R
 import com.example.openeer.data.block.BlocksRepository
 import com.example.openeer.ui.PhotoViewerActivity
 import com.example.openeer.ui.SimplePlayer
+import com.example.openeer.ui.sheets.ChildTextEditorSheet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -60,9 +61,12 @@ class MediaActions(
                 )
             }
             is MediaStripItem.Text -> {
-                // Pour un post-it texte : simple aperçu via Toast (ou ouvrir un éditeur dédié plus tard)
-                val preview = item.preview.ifBlank { "…" }
-                Toast.makeText(activity, preview, Toast.LENGTH_SHORT).show()
+                val sheet = ChildTextEditorSheet.edit(
+                    noteId = item.noteId,
+                    blockId = item.blockId,
+                    initialContent = item.content,
+                )
+                sheet.show(activity.supportFragmentManager, "child_text")
             }
         }
     }
@@ -96,7 +100,7 @@ class MediaActions(
                 shareFile(item.mediaUri, item.mimeType ?: "audio/*")
             }
             is MediaStripItem.Text -> {
-                shareText(item.preview)
+                shareText(item.content)
             }
         }
     }

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
@@ -31,9 +31,17 @@ sealed class MediaStripItem {
      */
     data class Text(
         override val blockId: Long,
-        val preview: String,
+        val noteId: Long,
+        val content: String,
     ) : MediaStripItem() {
         override val mediaUri: String? = null
         override val mimeType: String? = null
+
+        val preview: String
+            get() = content
+                .lineSequence()
+                .firstOrNull()
+                ?.trim()
+                .orEmpty()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
 
     <string name="sketch_clear_confirm_title">Supprimer le croquis ?</string>
     <string name="sketch_clear_confirm_message">Tout le dessin sera effacé.</string>
+
+    <string name="child_text_editor_edit_title">Modifier le post-it</string>
 </resources>


### PR DESCRIPTION
## Summary
- open ChildTextEditorSheet when clicking a text post-it in the media strip
- provide note context and full text content so the sheet can be prefilled for editing
- extend the child text editor sheet to update existing blocks and add an edit title string

## Testing
- ./gradlew lint *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cb228d0cd8832d8061bd705ac25613