### PR TITLE
Add title input to child text editor sheet

### DIFF
--- a/app/src/main/res/layout/sheet_child_text_editor.xml
+++ b/app/src/main/res/layout/sheet_child_text_editor.xml
@@ -30,6 +30,15 @@
             android:layout_marginBottom="8dp" />
 
         <EditText
+            android:id="@+id/inputTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Titre"
+            android:background="@android:color/transparent"
+            android:padding="12dp"
+            android:layout_marginBottom="8dp" />
+
+        <EditText
             android:id="@+id/inputText"
             android:layout_width="match_parent"
             android:layout_height="120dp"


### PR DESCRIPTION
## Summary
- add a title EditText to the child text editor sheet layout
- split stored block text into title and body fields when opening the sheet
- recombine the title and body when saving a child text block

## Testing
- ./gradlew test *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb70579fbc832daeb968973eb92400