### PR TITLE
Group media strip items by category piles

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaCategory.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaCategory.kt
@@ -1,0 +1,11 @@
+package com.example.openeer.ui.panel.media
+
+/**
+ * Catégories fonctionnelles pour regrouper les médias du bandeau.
+ */
+enum class MediaCategory {
+    PHOTO,
+    SKETCH,
+    AUDIO,
+    TEXT,
+}

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
@@ -11,6 +11,16 @@ sealed class MediaStripItem {
     abstract val mediaUri: String?
     abstract val mimeType: String?
 
+    data class Pile(
+        val category: MediaCategory,
+        val count: Int,
+        val cover: MediaStripItem,
+    ) : MediaStripItem() {
+        override val blockId: Long = -(category.ordinal + 1).toLong()
+        override val mediaUri: String? = cover.mediaUri
+        override val mimeType: String? = cover.mimeType
+    }
+
     data class Image(
         override val blockId: Long,
         override val mediaUri: String,   // chemin/uri (photo, sketch)


### PR DESCRIPTION
## Summary
- add a MediaCategory enum and a Pile strip item to model grouped media categories
- update the media strip adapter to render pile covers with a count badge and forward actions
- group block entities by media category when building the strip contents

## Testing
- ./gradlew :app:lint *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb74962744832d8a6f395c46f4776f