### PR TITLE
Add pile support to media strip adapter

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -73,6 +73,7 @@ class NotePanelController(
 
     private val mediaAdapter = MediaStripAdapter(
         onClick = { item -> mediaActions.handleClick(item) },
+        onPileClick = { category -> mediaActions.handlePileClick(category) },
         onLongPress = { view, item -> mediaActions.showMenu(view, item) }
     )
 

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaActions.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaActions.kt
@@ -3,6 +3,7 @@ package com.example.openeer.ui.panel.media
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.util.Log
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -28,6 +29,10 @@ class MediaActions(
     private val blocksRepo: BlocksRepository
 ) {
     private val uiScope = CoroutineScope(Dispatchers.Main)
+
+    fun handlePileClick(category: MediaCategory) {
+        Log.d("MediaActions", "Pile click: $category")
+    }
 
     fun handleClick(item: MediaStripItem) {
         when (item) {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,3 @@
+<resources>
+    <dimen name="media_strip_item_size">90dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- add a dedicated pile view type in `MediaStripAdapter` that renders covers and count badges in 90dp cards
- introduce a shared `media_strip_item_size` dimension and expose a pile click callback through the controller
- log pile click events from `MediaActions` for now

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb78cd9150832d81fa268f8a960b5e