### PR TITLE
Add post-it viewer bottom sheet

### DIFF
--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -18,6 +18,10 @@ class BlocksRepository(
 
     fun observeBlocks(noteId: Long): Flow<List<BlockEntity>> = blockDao.observeBlocks(noteId)
 
+    suspend fun getBlock(blockId: Long): BlockEntity? = withContext(io) {
+        blockDao.getById(blockId)
+    }
+
     private suspend fun insert(noteId: Long, template: BlockEntity): Long =
         withContext(io) { blockDao.insertAtEnd(noteId, template) }
 

--- a/app/src/main/java/com/example/openeer/ui/sheets/ChildTextViewerSheet.kt
+++ b/app/src/main/java/com/example/openeer/ui/sheets/ChildTextViewerSheet.kt
@@ -1,0 +1,174 @@
+package com.example.openeer.ui.sheets
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageButton
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.lifecycleScope
+import com.example.openeer.R
+import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.block.BlockType
+import com.example.openeer.data.block.BlocksRepository
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ChildTextViewerSheet : BottomSheetDialogFragment() {
+
+    companion object {
+        private const val ARG_NOTE_ID = "arg_note_id"
+        private const val ARG_BLOCK_ID = "arg_block_id"
+
+        fun newInstance(noteId: Long, blockId: Long): ChildTextViewerSheet =
+            ChildTextViewerSheet().apply {
+                arguments = bundleOf(
+                    ARG_NOTE_ID to noteId,
+                    ARG_BLOCK_ID to blockId,
+                )
+            }
+
+        fun show(fm: FragmentManager, noteId: Long, blockId: Long) {
+            newInstance(noteId, blockId).show(fm, "child_text_viewer_$blockId")
+        }
+    }
+
+    private val noteId: Long
+        get() = requireArguments().getLong(ARG_NOTE_ID)
+
+    private val blockId: Long
+        get() = requireArguments().getLong(ARG_BLOCK_ID)
+
+    private val blocksRepo: BlocksRepository by lazy {
+        val db = AppDatabase.get(requireContext())
+        BlocksRepository(db.blockDao(), db.noteDao())
+    }
+
+    private var currentContent: String = ""
+
+    private var postitText: TextView? = null
+    private var btnEdit: Button? = null
+    private var btnShare: ImageButton? = null
+    private var btnDelete: ImageButton? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View = inflater.inflate(R.layout.bottomsheet_child_text_viewer, container, false)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        postitText = view.findViewById(R.id.postitText)
+        btnEdit = view.findViewById<Button>(R.id.btnEdit).also { button ->
+            button.setOnClickListener { openEditor() }
+            button.isEnabled = false
+        }
+        view.findViewById<Button>(R.id.btnClose).setOnClickListener { dismiss() }
+        btnShare = view.findViewById<ImageButton>(R.id.btnShare).also { button ->
+            button.setOnClickListener { shareCurrentContent() }
+            button.isEnabled = false
+        }
+        btnDelete = view.findViewById<ImageButton>(R.id.btnDelete).also { button ->
+            button.setOnClickListener { confirmDelete() }
+            button.isEnabled = false
+        }
+
+        refreshContent()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        (dialog as? BottomSheetDialog)?.behavior?.apply {
+            state = BottomSheetBehavior.STATE_EXPANDED
+            skipCollapsed = true
+            isDraggable = true
+            peekHeight = 0
+            expandedOffset = 0
+        }
+    }
+
+    private fun refreshContent() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val block = withContext(Dispatchers.IO) { blocksRepo.getBlock(blockId) }
+            if (block == null || block.type != BlockType.TEXT) {
+                currentContent = ""
+                postitText?.text = ""
+                btnEdit?.isEnabled = false
+                btnShare?.isEnabled = false
+                btnDelete?.isEnabled = false
+                context?.let { ctx ->
+                    Toast.makeText(ctx, ctx.getString(R.string.media_missing_file), Toast.LENGTH_SHORT).show()
+                }
+                if (isAdded) {
+                    dismiss()
+                }
+                return@launch
+            }
+
+            currentContent = block.text.orEmpty()
+            postitText?.text = currentContent
+            btnEdit?.isEnabled = true
+            btnShare?.isEnabled = currentContent.isNotBlank()
+            btnDelete?.isEnabled = true
+        }
+    }
+
+    private fun openEditor() {
+        val content = currentContent
+        ChildTextEditorSheet.edit(noteId, blockId, content).apply {
+            onSaved = { _, _ -> refreshContent() }
+        }.show(parentFragmentManager, "child_text_edit_$blockId")
+    }
+
+    private fun shareCurrentContent() {
+        val ctx = context ?: return
+        val text = currentContent.ifBlank { " " }
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+        runCatching {
+            startActivity(Intent.createChooser(intent, getString(R.string.media_action_share)))
+        }.onFailure {
+            Toast.makeText(ctx, getString(R.string.media_share_error), Toast.LENGTH_LONG).show()
+        }
+    }
+
+    private fun confirmDelete() {
+        val ctx = context ?: return
+        AlertDialog.Builder(ctx)
+            .setTitle(R.string.media_action_delete)
+            .setMessage(R.string.media_delete_confirm)
+            .setPositiveButton(R.string.action_validate) { _, _ -> performDelete() }
+            .setNegativeButton(R.string.action_cancel, null)
+            .show()
+    }
+
+    private fun performDelete() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching { blocksRepo.deleteBlock(blockId) }.isSuccess
+            }
+            val ctx = context ?: return@launch
+            if (result) {
+                Toast.makeText(ctx, ctx.getString(R.string.media_delete_done), Toast.LENGTH_SHORT).show()
+                dismiss()
+            } else {
+                Toast.makeText(ctx, ctx.getString(R.string.media_delete_error), Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+}
+

--- a/app/src/main/res/layout/bottomsheet_child_text_viewer.xml
+++ b/app/src/main/res/layout/bottomsheet_child_text_viewer.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/viewerTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/media_category_text"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <ImageButton
+                android:id="@+id/btnShare"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/media_action_share"
+                android:padding="4dp"
+                android:src="@android:drawable/ic_menu_share"
+                android:tint="?attr/colorControlNormal" />
+
+            <ImageButton
+                android:id="@+id/btnDelete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/media_action_delete"
+                android:padding="4dp"
+                android:src="@android:drawable/ic_menu_delete"
+                android:tint="?attr/colorControlNormal" />
+
+            <Button
+                android:id="@+id/btnEdit"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/action_edit" />
+
+            <Button
+                android:id="@+id/btnClose"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="@string/action_close" />
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="12dp" />
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fillViewport="true">
+
+            <TextView
+                android:id="@+id/postitText"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:padding="12dp"
+                android:scrollbars="vertical"
+                android:textSize="16sp" />
+        </ScrollView>
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     <string name="action_validate">Valider</string>
     <string name="action_cancel">Annuler</string>
+    <string name="action_edit">Modifier</string>
+    <string name="action_close">Fermer</string>
 
     <string name="msg_block_text_added">Bloc texte ajouté</string>
     <string name="msg_sketch_added">Croquis ajouté</string>


### PR DESCRIPTION
## Summary
- add a ChildTextViewerSheet bottom sheet to display existing text blocks with edit, share and delete actions
- add a dedicated layout and supporting strings for the viewer UI
- expose a helper on BlocksRepository to fetch a block by id

## Testing
- ❌ `./gradlew :app:lint` *(fails: Android SDK is not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe9e74044832da85dd9d192ec1ef6