### PR TITLE
Expand media grid bottom sheet

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/sheets/MediaGridSheet.kt
+++ b/app/src/main/java/com/example/openeer/ui/sheets/MediaGridSheet.kt
@@ -131,11 +131,14 @@ class MediaGridSheet : BottomSheetDialogFragment() {
     // Forcer l’ouverture en plein écran (développé) et ignorer l’état replié
     override fun onStart() {
         super.onStart()
-        (dialog as? BottomSheetDialog)?.behavior?.apply {
+        val bottomSheetView = (dialog as? BottomSheetDialog)
+            ?.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
+            ?: return
+        BottomSheetBehavior.from(bottomSheetView).apply {
             state = BottomSheetBehavior.STATE_EXPANDED
+            peekHeight = 0
             skipCollapsed = true
             isDraggable = true
-            peekHeight = 0
             expandedOffset = 0
         }
     }


### PR DESCRIPTION
## Summary
- ensure MediaGridSheet retrieves the bottom sheet behavior from the dialog content view
- force the sheet to start expanded with zero peek height to avoid the collapsed banner state

## Testing
- ./gradlew :app:lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbef4bad9c832d83ca546f3ac7a368