### PR TITLE
feat(camera): UI shell for CameraCaptureActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -60,6 +60,11 @@
             android:exported="false"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
+        <activity
+            android:name=".ui.capture.CameraCaptureActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+
         <service
             android:name=".audio.RecorderService"
             android:exported="false"

--- a/app/src/main/java/com/example/openeer/ui/capture/CameraCaptureActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/capture/CameraCaptureActivity.kt
@@ -1,0 +1,49 @@
+package com.example.openeer.ui.capture
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.View
+import androidx.activity.addCallback
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import com.example.openeer.R
+import com.google.android.material.appbar.MaterialToolbar
+
+class CameraCaptureActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContentView(R.layout.activity_camera_capture)
+
+        val toolbar: MaterialToolbar = findViewById(R.id.cameraToolbar)
+        val controls: View = findViewById(R.id.cameraControls)
+        val root: View = findViewById(R.id.cameraRoot)
+
+        val originalToolbarPaddingTop = toolbar.paddingTop
+        val originalControlsPaddingBottom = controls.paddingBottom
+
+        toolbar.setNavigationOnClickListener { finishWithResultOk() }
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            toolbar.updatePadding(top = originalToolbarPaddingTop + systemBars.top)
+            controls.updatePadding(bottom = originalControlsPaddingBottom + systemBars.bottom)
+            insets
+        }
+
+        ViewCompat.requestApplyInsets(root)
+
+        onBackPressedDispatcher.addCallback(this) {
+            finishWithResultOk()
+        }
+    }
+
+    private fun finishWithResultOk() {
+        setResult(Activity.RESULT_OK)
+        finish()
+    }
+}

--- a/app/src/main/res/layout/activity_camera_capture.xml
+++ b/app/src/main/res/layout/activity_camera_capture.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/cameraRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/cameraToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_close"
+        app:title="@string/camera_capture_title" />
+
+    <View
+        android:id="@+id/cameraPreviewPlaceholder"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@android:color/black"
+        app:layout_constraintBottom_toTopOf="@+id/cameraControls"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/cameraToolbar" />
+
+    <LinearLayout
+        android:id="@+id/cameraControls"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingTop="16dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="32dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/openGalleryButton"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_weight="1"
+                android:text="@string/camera_capture_gallery" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/captureButton"
+                style="@style/Widget.Material3.Button.FilledButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_weight="1.3"
+                android:text="@string/camera_capture_button"
+                android:textAllCaps="true" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/screenshotButton"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/camera_capture_screenshot" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/captureStateIdle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_capture_state_idle"
+                android:textAllCaps="true"
+                android:textColor="@android:color/white"
+                android:textSize="12sp"
+                android:textStyle="bold" />
+
+            <Space
+                android:layout_width="16dp"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/captureStateHold"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_capture_state_hold"
+                android:textAllCaps="true"
+                android:textColor="#80FFFFFF"
+                android:textSize="12sp" />
+
+            <Space
+                android:layout_width="16dp"
+                android:layout_height="wrap_content" />
+
+            <TextView
+                android:id="@+id/captureStateLock"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/camera_capture_state_lock"
+                android:textAllCaps="true"
+                android:textColor="#80FFFFFF"
+                android:textSize="12sp" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,4 +58,12 @@
     <string name="sketch_clear_confirm_message">Tout le dessin sera effacé.</string>
 
     <string name="child_text_editor_edit_title">Modifier le post-it</string>
+
+    <string name="camera_capture_title">Caméra</string>
+    <string name="camera_capture_gallery">Galerie</string>
+    <string name="camera_capture_button">Capture</string>
+    <string name="camera_capture_screenshot">Capture d&#39;écran</string>
+    <string name="camera_capture_state_idle">Idle</string>
+    <string name="camera_capture_state_hold">Hold</string>
+    <string name="camera_capture_state_lock">Lock</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a CameraCaptureActivity that sets up a full screen preview placeholder and handles back navigation by returning RESULT_OK
- provide the layout skeleton with gallery, capture, and screenshot buttons plus visible capture state labels
- register the new activity and strings in the manifest/resources

## Testing
- `./gradlew lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc25207ac8832dbb5c4704a3aea512