### PR TITLE
feat(ui): video category + ▶ overlay in media strip

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -206,6 +206,9 @@ class NotePanelController(
                 BlockType.PHOTO -> block.mediaUri?.takeIf { it.isNotBlank() }?.let { uri ->
                     MediaCategory.PHOTO to MediaStripItem.Image(block.id, uri, block.mimeType, block.type)
                 }
+                BlockType.VIDEO -> block.mediaUri?.takeIf { it.isNotBlank() }?.let { uri ->
+                    MediaCategory.VIDEO to MediaStripItem.Video(block.id, uri, block.mimeType)
+                }
                 BlockType.SKETCH -> block.mediaUri?.takeIf { it.isNotBlank() }?.let { uri ->
                     MediaCategory.SKETCH to MediaStripItem.Image(block.id, uri, block.mimeType, block.type)
                 }

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaCategory.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaCategory.kt
@@ -5,6 +5,7 @@ package com.example.openeer.ui.panel.media
  */
 enum class MediaCategory {
     PHOTO,
+    VIDEO,
     SKETCH,
     AUDIO,
     TEXT,

--- a/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
+++ b/app/src/main/java/com/example/openeer/ui/panel/media/MediaStripItem.kt
@@ -28,6 +28,12 @@ sealed class MediaStripItem {
         val type: BlockType,             // PHOTO ou SKETCH
     ) : MediaStripItem()
 
+    data class Video(
+        override val blockId: Long,
+        override val mediaUri: String,   // chemin/uri vidéo
+        override val mimeType: String?,
+    ) : MediaStripItem()
+
     data class Audio(
         override val blockId: Long,
         override val mediaUri: String,   // chemin local attendu

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,8 +17,10 @@
     <string name="media_delete_error">Suppression impossible</string>
     <string name="media_share_error">Partage impossible</string>
     <string name="media_missing_file">Fichier introuvable</string>
+    <string name="media_video_open_error">Lecture vidéo impossible</string>
 
     <string name="media_category_photo">Photos</string>
+    <string name="media_category_video">Vidéos</string>
     <string name="media_category_sketch">Croquis</string>
     <string name="media_category_audio">Audios</string>
     <string name="media_category_text">Post-it</string>


### PR DESCRIPTION
## Summary
- add the video media category and strip item model so captured videos surface in the note panel
- render video entries with a play overlay in the media strip and media grid
- route video clicks through the system player while enabling share/delete flows and localized labels

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc2f2c7eac832da7a5228be7bef4c5