### PR TITLE
refactor(camera): route main camera button to CameraCaptureActivity

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -2,6 +2,7 @@
 package com.example.openeer.ui
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
@@ -24,6 +25,7 @@ import com.example.openeer.data.Note
 import com.example.openeer.data.NoteRepository
 import com.example.openeer.data.block.BlocksRepository
 import com.example.openeer.databinding.ActivityMainBinding
+import com.example.openeer.ui.capture.CameraCaptureActivity
 import com.example.openeer.ui.capture.CaptureLauncher
 import com.example.openeer.ui.editor.EditorBodyController
 import com.example.openeer.ui.sheets.ChildTextEditorSheet
@@ -206,7 +208,10 @@ class MainActivity : AppCompatActivity() {
         b.btnPhoto.setOnClickListener {
             lifecycleScope.launch {
                 val nid = ensureOpenNote()
-                captureLauncher.launchPhotoCapture(nid)
+                val intent = Intent(this@MainActivity, CameraCaptureActivity::class.java).apply {
+                    putExtra(CameraCaptureActivity.EXTRA_NOTE_ID, nid)
+                }
+                startActivity(intent)
             }
         }
         b.btnSketch.setOnClickListener {

--- a/app/src/main/java/com/example/openeer/ui/capture/CameraCaptureActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/capture/CameraCaptureActivity.kt
@@ -367,6 +367,7 @@ class CameraCaptureActivity : AppCompatActivity() {
     private enum class CaptureState { IDLE, HOLD, LOCK }
 
     companion object {
+        const val EXTRA_NOTE_ID = "extra_note_id"
         const val EXTRA_LAST_PHOTO = "extra_last_photo"
         const val EXTRA_LAST_VIDEO_URI = "extra_last_video"
     }


### PR DESCRIPTION
## Summary
- launch `CameraCaptureActivity` when the main photo button is tapped, passing along the open note id
- add a companion constant for the note id extra in `CameraCaptureActivity`

## Testing
- ./gradlew lint *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc32d97c7c832d997e22f5f6b1291c