### PR TITLE
feat(screenshot): media projection with crop overlay

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -65,6 +65,11 @@
             android:exported="false"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
+        <activity
+            android:name=".ui.screenshot.ScreenCaptureActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+
         <service
             android:name=".audio.RecorderService"
             android:exported="false"

--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -62,7 +62,8 @@ class BlocksRepository(
         width: Int? = null,
         height: Int? = null,
         mimeType: String? = "image/*",
-        groupId: String? = null
+        groupId: String? = null,
+        extra: String? = null,
     ): Long {
         val now = System.currentTimeMillis()
         val block = BlockEntity(
@@ -74,6 +75,7 @@ class BlocksRepository(
             mimeType = mimeType,
             width = width,
             height = height,
+            extra = extra,
             createdAt = now,
             updatedAt = now
         )

--- a/app/src/main/java/com/example/openeer/ui/screenshot/ScreenCaptureActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/screenshot/ScreenCaptureActivity.kt
@@ -1,0 +1,354 @@
+package com.example.openeer.ui.screenshot
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.graphics.PixelFormat
+import android.graphics.RectF
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.Image
+import android.media.ImageReader
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.View
+import android.widget.ImageView
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
+import androidx.lifecycle.lifecycleScope
+import com.example.openeer.R
+import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.block.BlocksRepository
+import com.example.openeer.ui.util.toast
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.max
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class ScreenCaptureActivity : AppCompatActivity() {
+
+    companion object {
+        const val EXTRA_NOTE_ID = "extra_note_id"
+        const val EXTRA_BLOCK_ID = "extra_block_id"
+        const val EXTRA_FILE_PATH = "extra_file_path"
+    }
+
+    private lateinit var toolbar: MaterialToolbar
+    private lateinit var preview: ImageView
+    private lateinit var overlay: SelectionOverlayView
+    private lateinit var progress: ProgressBar
+    private lateinit var saveButton: MaterialButton
+    private lateinit var retryButton: MaterialButton
+    private lateinit var controlsContainer: View
+
+    private val projectionManager: MediaProjectionManager by lazy {
+        getSystemService(MediaProjectionManager::class.java)
+    }
+
+    private val blocksRepository: BlocksRepository by lazy {
+        val db = AppDatabase.get(this)
+        BlocksRepository(db.blockDao(), db.noteDao())
+    }
+
+    private val projectionLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+                startProjection(result.resultCode, result.data!!)
+            } else {
+                toast(R.string.screen_capture_cancelled, Toast.LENGTH_SHORT)
+                finishWithCanceled()
+            }
+        }
+
+    private var noteId: Long? = null
+    private var capturedBitmap: Bitmap? = null
+
+    private var mediaProjection: MediaProjection? = null
+    private var virtualDisplay: VirtualDisplay? = null
+    private var imageReader: ImageReader? = null
+    private var captureThread: HandlerThread? = null
+    private var imageHandler: Handler? = null
+    private var hasCapturedFrame: Boolean = false
+    private var userInitiatedStop: Boolean = false
+
+    private val projectionCallback = object : MediaProjection.Callback() {
+        override fun onStop() {
+            super.onStop()
+            if (!hasCapturedFrame && !userInitiatedStop) {
+                runOnUiThread {
+                    toast(R.string.screen_capture_protected, Toast.LENGTH_LONG)
+                    finishWithCanceled()
+                }
+            }
+            userInitiatedStop = false
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        setContentView(R.layout.activity_screen_capture)
+
+        noteId = intent?.getLongExtra(EXTRA_NOTE_ID, -1L)?.takeIf { it > 0 }
+
+        toolbar = findViewById(R.id.screenCaptureToolbar)
+        preview = findViewById(R.id.screenCapturePreview)
+        overlay = findViewById(R.id.screenSelectionOverlay)
+        progress = findViewById(R.id.screenCaptureProgress)
+        saveButton = findViewById(R.id.screenCaptureSave)
+        retryButton = findViewById(R.id.screenCaptureRetry)
+        controlsContainer = findViewById(R.id.screenCaptureControls)
+
+        setupToolbar()
+        setupButtons()
+        requestProjection()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        releaseProjectionResources(suppressCallback = true)
+        capturedBitmap?.recycle()
+        capturedBitmap = null
+    }
+
+    private fun setupToolbar() {
+        toolbar.title = getString(R.string.screen_capture_title)
+        toolbar.navigationIcon = AppCompatResources.getDrawable(this, R.drawable.ic_close)
+        toolbar.setNavigationOnClickListener { finishWithCanceled() }
+
+        val root: View = findViewById(R.id.screenCaptureRoot)
+        val originalToolbarPaddingTop = toolbar.paddingTop
+        val originalControlsPaddingBottom = controlsContainer.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(root) { _, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            toolbar.updatePadding(top = originalToolbarPaddingTop + systemBars.top)
+            controlsContainer.updatePadding(bottom = originalControlsPaddingBottom + systemBars.bottom)
+            insets
+        }
+        ViewCompat.requestApplyInsets(root)
+    }
+
+    private fun setupButtons() {
+        saveButton.isEnabled = false
+        saveButton.setOnClickListener { persistSelection() }
+        retryButton.setOnClickListener { restartCapture() }
+    }
+
+    private fun requestProjection() {
+        progress.isVisible = true
+        saveButton.isEnabled = false
+        capturedBitmap?.recycle()
+        capturedBitmap = null
+        overlay.setImageBounds(null)
+        preview.setImageDrawable(null)
+        val captureIntent = projectionManager.createScreenCaptureIntent()
+        projectionLauncher.launch(captureIntent)
+    }
+
+    private fun restartCapture() {
+        releaseProjectionResources(suppressCallback = true)
+        requestProjection()
+    }
+
+    private fun startProjection(resultCode: Int, data: Intent) {
+        releaseProjectionResources(suppressCallback = true)
+        userInitiatedStop = false
+        val metrics = resources.displayMetrics
+        val width = metrics.widthPixels
+        val height = metrics.heightPixels
+
+        captureThread = HandlerThread("screen_capture").apply { start() }
+        imageHandler = Handler(captureThread!!.looper)
+
+        imageReader = ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 2).apply {
+            setOnImageAvailableListener({ reader ->
+                processImage(reader)
+            }, imageHandler)
+        }
+
+        hasCapturedFrame = false
+        mediaProjection = projectionManager.getMediaProjection(resultCode, data)?.also { projection ->
+            projection.registerCallback(projectionCallback, imageHandler)
+        }
+
+        val densityDpi = metrics.densityDpi
+        virtualDisplay = mediaProjection?.createVirtualDisplay(
+            "screen_capture",
+            width,
+            height,
+            densityDpi,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            imageReader?.surface,
+            null,
+            imageHandler
+        )
+    }
+
+    private fun processImage(reader: ImageReader) {
+        val image = reader.acquireLatestImage() ?: return
+        reader.setOnImageAvailableListener(null, null)
+        val bitmap = try {
+            image.toBitmap()
+        } catch (t: Throwable) {
+            null
+        } finally {
+            image.close()
+        }
+        if (bitmap == null) {
+            releaseProjectionResources()
+            runOnUiThread {
+                toast(R.string.screen_capture_protected, Toast.LENGTH_LONG)
+                finishWithCanceled()
+            }
+            return
+        }
+        hasCapturedFrame = true
+        capturedBitmap = bitmap
+        releaseProjectionResources(suppressCallback = true)
+        runOnUiThread {
+            progress.isVisible = false
+            preview.setImageBitmap(bitmap)
+            saveButton.isEnabled = true
+            preview.post { updateOverlayBounds() }
+        }
+    }
+
+    private fun updateOverlayBounds() {
+        val drawable = preview.drawable ?: return
+        val imageMatrix: Matrix = preview.imageMatrix
+        val drawableRect = RectF(0f, 0f, drawable.intrinsicWidth.toFloat(), drawable.intrinsicHeight.toFloat())
+        imageMatrix.mapRect(drawableRect)
+        val left = drawableRect.left + preview.paddingLeft
+        val top = drawableRect.top + preview.paddingTop
+        val right = drawableRect.right + preview.paddingLeft
+        val bottom = drawableRect.bottom + preview.paddingTop
+        overlay.setImageBounds(RectF(left, top, right, bottom))
+    }
+
+    private fun persistSelection() {
+        val bitmap = capturedBitmap ?: return
+        val normalized = overlay.getNormalizedSelection() ?: RectF(0f, 0f, 1f, 1f)
+        val cropRect = normalized.toBitmapRect(bitmap.width, bitmap.height)
+        val safeRect = cropRect ?: RectF(0f, 0f, bitmap.width.toFloat(), bitmap.height.toFloat())
+        val cropLeft = floor(safeRect.left).toInt().coerceIn(0, bitmap.width - 1)
+        val cropTop = floor(safeRect.top).toInt().coerceIn(0, bitmap.height - 1)
+        val cropRight = ceil(safeRect.right).toInt().coerceIn(cropLeft + 1, bitmap.width)
+        val cropBottom = ceil(safeRect.bottom).toInt().coerceIn(cropTop + 1, bitmap.height)
+        val cropWidth = max(1, cropRight - cropLeft)
+        val cropHeight = max(1, cropBottom - cropTop)
+
+        val cropped = Bitmap.createBitmap(bitmap, cropLeft, cropTop, cropWidth, cropHeight)
+        lifecycleScope.launch {
+            val file = withContext(Dispatchers.IO) {
+                saveBitmapToFile(cropped)
+            }
+            if (file == null) {
+                toast(R.string.screen_capture_error, Toast.LENGTH_LONG)
+                return@launch
+            }
+            val nid = noteId
+            var blockId: Long? = null
+            if (nid != null) {
+                blockId = withContext(Dispatchers.IO) {
+                    blocksRepository.appendPhoto(
+                        nid,
+                        file.absolutePath,
+                        width = cropWidth,
+                        height = cropHeight,
+                        mimeType = "image/png",
+                        extra = "{\"source\":\"screenshot\"}"
+                    )
+                }
+            }
+            val data = Intent().apply {
+                file.absolutePath.let { putExtra(EXTRA_FILE_PATH, it) }
+                nid?.let { putExtra(EXTRA_NOTE_ID, it) }
+                blockId?.let { putExtra(EXTRA_BLOCK_ID, it) }
+            }
+            setResult(Activity.RESULT_OK, data)
+            finish()
+        }
+    }
+
+    private fun finishWithCanceled() {
+        setResult(Activity.RESULT_CANCELED)
+        finish()
+    }
+
+    private fun releaseProjectionResources(suppressCallback: Boolean = false) {
+        virtualDisplay?.release()
+        virtualDisplay = null
+        imageReader?.setOnImageAvailableListener(null, null)
+        imageReader?.close()
+        imageReader = null
+        mediaProjection?.let { projection ->
+            if (suppressCallback) {
+                userInitiatedStop = true
+            }
+            projection.unregisterCallback(projectionCallback)
+            projection.stop()
+        }
+        mediaProjection = null
+        captureThread?.quitSafely()
+        captureThread = null
+        imageHandler = null
+    }
+
+    private fun Image.toBitmap(): Bitmap? {
+        val plane = planes.firstOrNull() ?: return null
+        val buffer = plane.buffer ?: return null
+        if (buffer.remaining() == 0) return null
+        val pixelStride = plane.pixelStride
+        val rowStride = plane.rowStride
+        val rowPadding = rowStride - pixelStride * width
+        val bitmapWidth = width + rowPadding / pixelStride
+        val bitmap = Bitmap.createBitmap(bitmapWidth, height, Bitmap.Config.ARGB_8888)
+        buffer.rewind()
+        bitmap.copyPixelsFromBuffer(buffer)
+        return Bitmap.createBitmap(bitmap, 0, 0, width, height)
+    }
+
+    private fun RectF.toBitmapRect(bitmapWidth: Int, bitmapHeight: Int): RectF? {
+        if (width() <= 0f || height() <= 0f) return null
+        val scaledLeft = (this.left * bitmapWidth).coerceIn(0f, bitmapWidth.toFloat())
+        val scaledTop = (this.top * bitmapHeight).coerceIn(0f, bitmapHeight.toFloat())
+        val scaledRight = (this.right * bitmapWidth).coerceIn(scaledLeft + 1f, bitmapWidth.toFloat())
+        val scaledBottom = (this.bottom * bitmapHeight).coerceIn(scaledTop + 1f, bitmapHeight.toFloat())
+        return RectF(scaledLeft, scaledTop, scaledRight, scaledBottom)
+    }
+
+    private suspend fun saveBitmapToFile(bitmap: Bitmap): File? {
+        val dir = File(filesDir, "images").apply { mkdirs() }
+        val file = File(dir, "screenshot_${System.currentTimeMillis()}.png")
+        try {
+            FileOutputStream(file).use { out ->
+                if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                    return null
+                }
+            }
+        } catch (ioe: IOException) {
+            return null
+        }
+        return file
+    }
+}

--- a/app/src/main/java/com/example/openeer/ui/screenshot/SelectionOverlayView.kt
+++ b/app/src/main/java/com/example/openeer/ui/screenshot/SelectionOverlayView.kt
@@ -1,0 +1,149 @@
+package com.example.openeer.ui.screenshot
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.PointF
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import kotlin.math.max
+import kotlin.math.min
+
+class SelectionOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : View(context, attrs) {
+
+    private val dimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.parseColor("#80000000")
+    }
+
+    private val clearPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        xfermode = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
+    }
+
+    private val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        style = Paint.Style.STROKE
+        strokeWidth = resources.displayMetrics.density * 2f
+    }
+
+    private val selectionPath = Path()
+
+    private var imageBounds: RectF? = null
+    private var selectionRect: RectF? = null
+    private var touchStart: PointF? = null
+
+    init {
+        setLayerType(LAYER_TYPE_SOFTWARE, null)
+        isClickable = true
+    }
+
+    fun setImageBounds(bounds: RectF?) {
+        imageBounds = bounds?.let { RectF(it) }
+        selectionRect = bounds?.let { RectF(it) }
+        isEnabled = bounds != null
+        invalidate()
+    }
+
+    fun resetSelection() {
+        selectionRect = imageBounds?.let { RectF(it) }
+        invalidate()
+    }
+
+    fun clearSelection() {
+        selectionRect = null
+        invalidate()
+    }
+
+    fun hasSelection(): Boolean = selectionRect != null
+
+    fun getNormalizedSelection(): RectF? {
+        val bounds = imageBounds ?: return null
+        val selection = selectionRect ?: return null
+        val width = bounds.width().takeIf { it > 0f } ?: return null
+        val height = bounds.height().takeIf { it > 0f } ?: return null
+        val left = ((selection.left - bounds.left) / width).coerceIn(0f, 1f)
+        val top = ((selection.top - bounds.top) / height).coerceIn(0f, 1f)
+        val right = ((selection.right - bounds.left) / width).coerceIn(0f, 1f)
+        val bottom = ((selection.bottom - bounds.top) / height).coerceIn(0f, 1f)
+        return RectF(left, top, right, bottom)
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val bounds = imageBounds ?: return false
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                if (!bounds.contains(event.x, event.y)) {
+                    return false
+                }
+                val startX = event.x.coerceIn(bounds.left, bounds.right)
+                val startY = event.y.coerceIn(bounds.top, bounds.bottom)
+                touchStart = PointF(startX, startY)
+                selectionRect = RectF(startX, startY, startX, startY)
+                parent?.requestDisallowInterceptTouchEvent(true)
+                invalidate()
+                return true
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                val start = touchStart ?: return false
+                val currentX = event.x.coerceIn(bounds.left, bounds.right)
+                val currentY = event.y.coerceIn(bounds.top, bounds.bottom)
+                val left = min(start.x, currentX)
+                val top = min(start.y, currentY)
+                val right = max(start.x, currentX)
+                val bottom = max(start.y, currentY)
+                if (selectionRect == null) {
+                    selectionRect = RectF(left, top, right, bottom)
+                } else {
+                    selectionRect?.set(left, top, right, bottom)
+                }
+                clampSelection()
+                invalidate()
+                return true
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                touchStart = null
+                clampSelection()
+                parent?.requestDisallowInterceptTouchEvent(false)
+                invalidate()
+                return true
+            }
+        }
+        return super.onTouchEvent(event)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        val selection = selectionRect ?: return
+        val save = canvas.saveLayer(null, null)
+        canvas.drawRect(0f, 0f, width.toFloat(), height.toFloat(), dimPaint)
+        selectionPath.reset()
+        selectionPath.addRect(selection, Path.Direction.CW)
+        canvas.drawPath(selectionPath, clearPaint)
+        canvas.drawRect(selection, borderPaint)
+        canvas.restoreToCount(save)
+    }
+
+    private fun clampSelection() {
+        val bounds = imageBounds ?: return
+        val selection = selectionRect ?: return
+        val left = selection.left.coerceIn(bounds.left, bounds.right)
+        val top = selection.top.coerceIn(bounds.top, bounds.bottom)
+        val right = selection.right.coerceIn(bounds.left, bounds.right)
+        val bottom = selection.bottom.coerceIn(bounds.top, bounds.bottom)
+        if (right - left < 1f || bottom - top < 1f) {
+            selection.set(bounds)
+        } else {
+            selection.set(left, top, right, bottom)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_screen_capture.xml
+++ b/app/src/main/res/layout/activity_screen_capture.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/screenCaptureRoot"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/screenCaptureToolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_close"
+        app:title="@string/screen_capture_title" />
+
+    <FrameLayout
+        android:id="@+id/screenCaptureContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:foregroundGravity="center"
+        app:layout_constraintBottom_toTopOf="@+id/screenCaptureControls"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/screenCaptureToolbar">
+
+        <ImageView
+            android:id="@+id/screenCapturePreview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="false"
+            android:contentDescription="@string/screen_capture_preview_description"
+            android:scaleType="fitCenter" />
+
+        <com.example.openeer.ui.screenshot.SelectionOverlayView
+            android:id="@+id/screenSelectionOverlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="visible" />
+
+        <ProgressBar
+            android:id="@+id/screenCaptureProgress"
+            style="@style/Widget.Material3.CircularProgressIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:indeterminate="true" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:id="@+id/screenCaptureControls"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingTop="12dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <TextView
+            android:id="@+id/screenCaptureHint"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/screen_capture_hint"
+            android:textColor="#B3FFFFFF"
+            android:textSize="14sp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/screenCaptureRetry"
+                style="@style/Widget.Material3.Button.TonalButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="12dp"
+                android:layout_weight="1"
+                android:text="@string/screen_capture_retry" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/screenCaptureSave"
+                style="@style/Widget.Material3.Button.FilledButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/screen_capture_save" />
+        </LinearLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,13 @@
     <string name="camera_capture_video_saved">Vidéo enregistrée</string>
     <string name="camera_capture_video_error">Échec enregistrement vidéo</string>
     <string name="camera_capture_video_start_error">Impossible de démarrer la vidéo</string>
+
+    <string name="screen_capture_title">Capture d&#39;écran</string>
+    <string name="screen_capture_hint">Faites glisser pour sélectionner la zone à conserver</string>
+    <string name="screen_capture_retry">Recommencer</string>
+    <string name="screen_capture_save">Enregistrer</string>
+    <string name="screen_capture_protected">Impossible de capturer du contenu protégé.</string>
+    <string name="screen_capture_error">Capture d&#39;écran impossible</string>
+    <string name="screen_capture_cancelled">Capture d&#39;écran annulée</string>
+    <string name="screen_capture_preview_description">Aperçu de la capture d&#39;écran</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated `ScreenCaptureActivity` that starts a media projection, captures a frame, shows a draggable crop overlay, and saves the cropped bitmap tagged as a screenshot block
- implement the reusable `SelectionOverlayView` plus a Material layout to host the screenshot preview, controls, and progress state
- extend `BlocksRepository.appendPhoto` so callers can attach an extra payload (used to mark screenshot sources) and register the new activity in the manifest with string resources

## Testing
- `./gradlew lint` *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc37593528832db29cae36d32dcd2e