### PR TITLE
chore(android): manifest & runtime permissions for camera/gallery/screenshot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO"/>
     <uses-feature android:name="android.hardware.camera" android:required="false"/>
 
     <!-- Localisation -->

--- a/app/src/main/java/com/example/openeer/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/OnboardingActivity.kt
@@ -33,6 +33,8 @@ class OnboardingActivity : AppCompatActivity() {
         permissionQueue.addLast(Manifest.permission.RECORD_AUDIO)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             permissionQueue.addLast(Manifest.permission.POST_NOTIFICATIONS)
+            permissionQueue.addLast(Manifest.permission.READ_MEDIA_IMAGES)
+            permissionQueue.addLast(Manifest.permission.READ_MEDIA_VIDEO)
         }
         permissionQueue.addLast(Manifest.permission.CAMERA)
         permissionQueue.addLast(Manifest.permission.ACCESS_FINE_LOCATION)

--- a/app/src/main/java/com/example/openeer/ui/capture/CaptureLauncher.kt
+++ b/app/src/main/java/com/example/openeer/ui/capture/CaptureLauncher.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.widget.ArrayAdapter
 import android.widget.ListView
@@ -162,11 +163,14 @@ class CaptureLauncher(
     }
 
     private fun openGallery() {
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
-            != PackageManager.PERMISSION_GRANTED
-        ) {
-            readMediaPermLauncher.launch(Manifest.permission.READ_MEDIA_IMAGES)
-            return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (
+                ContextCompat.checkSelfPermission(activity, Manifest.permission.READ_MEDIA_IMAGES)
+                != PackageManager.PERMISSION_GRANTED
+            ) {
+                readMediaPermLauncher.launch(Manifest.permission.READ_MEDIA_IMAGES)
+                return
+            }
         }
         pickPhotoLauncher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
     }


### PR DESCRIPTION
## Summary
- declare the READ_MEDIA_VIDEO permission alongside existing camera/audio entries
- request Android 13 media library access during onboarding when needed
- guard the gallery picker permission flow so it only runs on API 33+

## Testing
- ./gradlew lint *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c9703c8832d84eb82f3dc33f2a4