### PR TITLE
Add sprint 3 note search support

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -11,6 +11,14 @@ interface NoteDao {
     @Query("SELECT * FROM notes ORDER BY updatedAt DESC")
     fun getAllFlow(): Flow<List<Note>>
 
+    // --- Sprint 3: text search ---
+    @Query(
+        "SELECT * FROM notes " +
+            "WHERE (title LIKE '%' || :query || '%' OR body LIKE '%' || :query || '%') " +
+            "ORDER BY updatedAt DESC"
+    )
+    fun searchNotes(query: String): Flow<List<Note>>
+
     // ✅ nouveaux accès par ID
     @Query("SELECT * FROM notes WHERE id = :id LIMIT 1")
     fun getByIdFlow(id: Long): Flow<Note?>

--- a/app/src/main/java/com/example/openeer/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteRepository.kt
@@ -6,6 +6,9 @@ class NoteRepository(
 ) {
     val allNotes = noteDao.getAllFlow()
 
+    // --- Sprint 3: expose text search ---
+    fun searchNotes(query: String) = noteDao.searchNotes(query)
+
     fun note(id: Long) = noteDao.getByIdFlow(id)
     suspend fun noteOnce(id: Long) = noteDao.getByIdOnce(id)
 

--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -327,4 +327,9 @@ class MainActivity : AppCompatActivity() {
 
 class NotesVm(private val repo: NoteRepository) : ViewModel() {
     val notes = repo.allNotes
+
+    // --- Sprint 3: propagate search feature ---
+    fun search(query: String) = repo.searchNotes(query)
 }
+
+// TODO(sprint3): Hook up the future search UI component to NotesVm.search(query).

--- a/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
@@ -1,0 +1,49 @@
+package com.example.openeer.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NoteDaoSearchTest {
+    private lateinit var context: Context
+    private lateinit var database: AppDatabase
+    private lateinit var noteDao: NoteDao
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        noteDao = database.noteDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun searchReturnsNotesMatchingTitleOrBody() = runTest {
+        val grocery = Note(title = "Grocery list", body = "Buy apples and oranges")
+        val workout = Note(title = "Morning workout", body = "Pushups and squats")
+        val meeting = Note(title = null, body = "Meeting notes mention APPLE roadmap")
+
+        val groceryId = noteDao.insert(grocery)
+        noteDao.insert(workout)
+        val meetingId = noteDao.insert(meeting)
+
+        val results = noteDao.searchNotes("apple").first()
+
+        assertEquals(2, results.size)
+        assertTrue(results.any { it.id == groceryId })
+        assertTrue(results.any { it.id == meetingId })
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room DAO query to search notes by title or body text and expose it through the repository and view model
- document the upcoming Sprint 3 search UI hook in MainActivity
- add a unit test covering the DAO search behaviour for title and body matches

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de497fab50832db25935ea15325db7