### PR TITLE
Fix NoteDao search Robolectric test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,8 +116,9 @@ dependencies {
 
     // Tests
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.robolectric:robolectric:4.12.1")
-    testImplementation("androidx.test:core:1.6.1")
+    testImplementation("org.robolectric:robolectric:4.12.2")
+    testImplementation("androidx.test:core:1.5.0")
+    testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("androidx.room:room-testing:$room")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")

--- a/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
@@ -1,49 +1,83 @@
 package com.example.openeer.data
 
 import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class NoteDaoSearchTest {
-    private lateinit var context: Context
-    private lateinit var database: AppDatabase
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var db: AppDatabase
     private lateinit var noteDao: NoteDao
 
     @Before
     fun setUp() {
-        context = ApplicationProvider.getApplicationContext()
-        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
             .allowMainThreadQueries()
             .build()
-        noteDao = database.noteDao()
+        noteDao = db.noteDao()
     }
 
     @After
     fun tearDown() {
-        database.close()
+        db.close()
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun searchReturnsNotesMatchingTitleOrBody() = runTest {
-        val grocery = Note(title = "Grocery list", body = "Buy apples and oranges")
-        val workout = Note(title = "Morning workout", body = "Pushups and squats")
-        val meeting = Note(title = null, body = "Meeting notes mention APPLE roadmap")
+    fun searchNotesReturnsMatchesOrderedByRecency() = runTest {
+        val notes = listOf(
+            Note(
+                title = "Strategy meeting",
+                body = "Discuss apple launch plans",
+                createdAt = 1_000L,
+                updatedAt = 5_000L
+            ),
+            Note(
+                title = "Apple picking trip",
+                body = "Plan the weekend getaway",
+                createdAt = 2_000L,
+                updatedAt = 4_000L
+            ),
+            Note(
+                title = "Grocery list",
+                body = "Buy bananas and milk",
+                createdAt = 3_000L,
+                updatedAt = 3_000L
+            ),
+            Note(
+                title = "Dessert ideas",
+                body = "apple tart recipe to try",
+                createdAt = 4_000L,
+                updatedAt = 2_000L
+            )
+        )
 
-        val groceryId = noteDao.insert(grocery)
-        noteDao.insert(workout)
-        val meetingId = noteDao.insert(meeting)
+        val insertedIds = notes.map { note -> noteDao.insert(note) }
 
         val results = noteDao.searchNotes("apple").first()
 
-        assertEquals(2, results.size)
-        assertTrue(results.any { it.id == groceryId })
-        assertTrue(results.any { it.id == meetingId })
+        assertEquals(3, results.size)
+
+        val expectedOrder = listOf(insertedIds[0], insertedIds[1], insertedIds[3])
+        val actualOrder = results.map { it.id }
+        assertEquals(expectedOrder, actualOrder)
+        assertTrue(actualOrder.none { it == insertedIds[2] })
     }
 }


### PR DESCRIPTION
## Summary
- update the app module's JVM test dependencies for Robolectric, AndroidX core-testing, and coroutines
- rewrite NoteDaoSearchTest to build an in-memory Room database and verify search ordering

## Testing
- ./gradlew testDebug *(fails locally: Android SDK path not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de4e33d28c832da38c39ee9755a21e