### PR TITLE
Stabilize NoteDao search tests

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -16,7 +16,7 @@ interface NoteDao {
     @Query(
         "SELECT * FROM notes " +
             "WHERE (title LIKE '%' || :query || '%' OR body LIKE '%' || :query || '%') " +
-            "ORDER BY updatedAt DESC"
+            "ORDER BY updatedAt DESC, id DESC"
     )
     fun searchNotes(query: String): Flow<List<Note>>
 

--- a/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteDaoSearchTest.kt
@@ -5,8 +5,10 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.sqlite.db.SimpleSQLiteQuery
+import com.example.openeer.rules.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -22,6 +24,10 @@ class NoteDaoSearchTest {
 
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    // TODO(sprint3): test harness
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
 
     private lateinit var db: AppDatabase
     private lateinit var noteDao: NoteDao
@@ -71,6 +77,8 @@ class NoteDaoSearchTest {
         )
 
         val insertedIds = notes.map { note -> noteDao.insert(note) }
+
+        advanceUntilIdle()
 
         val results = noteDao.searchNotes("apple").first()
 
@@ -125,11 +133,13 @@ class NoteDaoSearchTest {
 
         val insertedIds = notes.map { note -> noteDao.insert(note) }
 
+        advanceUntilIdle()
+
         val appleQuery = SimpleSQLiteQuery(
             """
                 SELECT * FROM notes
                 WHERE tagsCsv IS NOT NULL AND ((',' || tagsCsv || ',') LIKE ?)
-                ORDER BY updatedAt DESC
+                ORDER BY updatedAt DESC, id DESC
             """.trimIndent(),
             arrayOf<Any>("%,apple,%")
         )
@@ -141,7 +151,7 @@ class NoteDaoSearchTest {
             """
                 SELECT * FROM notes
                 WHERE tagsCsv IS NOT NULL AND ((',' || tagsCsv || ',') LIKE ? OR (',' || tagsCsv || ',') LIKE ?)
-                ORDER BY updatedAt DESC
+                ORDER BY updatedAt DESC, id DESC
             """.trimIndent(),
             arrayOf<Any>("%,work,%", "%,apple,%")
         )

--- a/app/src/test/java/com/example/openeer/rules/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/openeer/rules/MainDispatcherRule.kt
@@ -1,0 +1,25 @@
+package com.example.openeer.rules
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+// TODO(sprint3): test harness
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val dispatcher: TestDispatcher = StandardTestDispatcher()
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable Main dispatcher test rule for coroutine-based JVM tests
- update NoteDaoSearchTest to use the rule, deterministic seeding, and stable ordering expectations
- ensure NoteDao text search orders by updated timestamp with an id tie-breaker for deterministic results

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Android SDK not configured in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de564155bc832db16f7db7f24cffbd