### PR TITLE
Add test stubs for Whisper JNI classes

### DIFF
--- a/app/src/test/java/com/whispercpp/java/whisper/WhisperContext.java
+++ b/app/src/test/java/com/whispercpp/java/whisper/WhisperContext.java
@@ -1,0 +1,54 @@
+package com.whispercpp.java.whisper;
+
+import android.content.res.AssetManager;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+/**
+ * Test-only stub implementation that bypasses JNI interactions.
+ */
+public class WhisperContext {
+
+  public WhisperContext() {
+  }
+
+  public String transcribeData(float[] data) throws ExecutionException, InterruptedException {
+    return "";
+  }
+
+  public List<WhisperSegment> transcribeDataWithTime(float[] data)
+      throws ExecutionException, InterruptedException {
+    return Collections.emptyList();
+  }
+
+  public String benchMemory(int nthreads) throws ExecutionException, InterruptedException {
+    return "";
+  }
+
+  public String benchGgmlMulMat(int nthreads) throws ExecutionException, InterruptedException {
+    return "";
+  }
+
+  public void release() throws ExecutionException, InterruptedException {
+    // no-op for tests
+  }
+
+  public static WhisperContext createContextFromFile(String filePath) {
+    return new WhisperContext();
+  }
+
+  public static WhisperContext createContextFromInputStream(InputStream stream) {
+    return new WhisperContext();
+  }
+
+  public static WhisperContext createContextFromAsset(AssetManager assetManager, String assetPath) {
+    return new WhisperContext();
+  }
+
+  public static String getSystemInfo() {
+    return "TEST";
+  }
+}

--- a/app/src/test/java/com/whispercpp/java/whisper/WhisperSegment.java
+++ b/app/src/test/java/com/whispercpp/java/whisper/WhisperSegment.java
@@ -1,0 +1,29 @@
+package com.whispercpp.java.whisper;
+
+/**
+ * Test-only stub representing a transcription segment.
+ */
+public class WhisperSegment {
+
+  private final long start;
+  private final long end;
+  private final String text;
+
+  public WhisperSegment(long start, long end, String text) {
+    this.start = start;
+    this.end = end;
+    this.text = text == null ? "" : text;
+  }
+
+  public long getStart() {
+    return start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public String getText() {
+    return text;
+  }
+}


### PR DESCRIPTION
## Summary
- add JVM-friendly test stubs for WhisperContext and WhisperSegment under src/test/java
- provide minimal implementations to satisfy unit tests without loading JNI libraries

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de5a8ab534832d92b90d1ba0e5810c