### PR TITLE
Add map screen skeleton and geotagged notes query

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,11 @@
             android:exported="false"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
+        <activity
+            android:name=".ui.map.MapActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+
         <!-- Ancien onboarding : plus de LAUNCHER -->
         <activity
             android:name=".ui.OnboardingActivity"

--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -20,6 +20,15 @@ interface NoteDao {
     )
     fun searchNotes(query: String): Flow<List<Note>>
 
+    // TODO(sprint3): expose geotagged list for map skeleton
+    @Query(
+        "SELECT * FROM notes " +
+            "WHERE ((placeLabel IS NOT NULL AND TRIM(placeLabel) != '') " +
+            "OR (lat IS NOT NULL AND lon IS NOT NULL)) " +
+            "ORDER BY updatedAt DESC, id DESC"
+    )
+    fun geotaggedNotes(): Flow<List<Note>>
+
     // ✅ nouveaux accès par ID
     @Query("SELECT * FROM notes WHERE id = :id LIMIT 1")
     fun getByIdFlow(id: Long): Flow<Note?>

--- a/app/src/main/java/com/example/openeer/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteRepository.kt
@@ -13,6 +13,9 @@ class NoteRepository(
     // --- Sprint 3: expose text search ---
     fun searchNotes(query: String) = noteDao.searchNotes(query)
 
+    // TODO(sprint3): expose geotagged list for map skeleton
+    fun geotaggedNotes() = noteDao.geotaggedNotes()
+
     fun searchNotesByTags(queryTags: List<String>): Flow<List<Note>> {
         val normalized = queryTags.map { it.trim().lowercase() }.filter { it.isNotBlank() }.distinct()
         if (normalized.isEmpty()) {

--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -2,6 +2,7 @@
 package com.example.openeer.ui
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
@@ -27,6 +28,7 @@ import com.example.openeer.databinding.ActivityMainBinding
 import com.example.openeer.ui.capture.CaptureLauncher
 import com.example.openeer.ui.editor.EditorBodyController
 import com.example.openeer.ui.sheets.ChildTextEditorSheet
+import com.example.openeer.ui.map.MapActivity
 import com.example.openeer.ui.util.configureSystemInsets
 import com.example.openeer.ui.util.snackbar
 import com.example.openeer.ui.util.toast
@@ -223,7 +225,7 @@ class MainActivity : AppCompatActivity() {
             b.recycler.post { b.recycler.requestFocus() }
         }
         b.btnMap.setOnClickListener {
-            b.root.snackbar("Carte/Itinéraire — bientôt disponible")
+            startActivity(Intent(this, MapActivity::class.java))
         }
 
         // Clic sur le corps = édition inline

--- a/app/src/main/java/com/example/openeer/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/map/MapActivity.kt
@@ -1,0 +1,92 @@
+package com.example.openeer.ui.map
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.example.openeer.R
+import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.Note
+import com.example.openeer.data.NoteRepository
+import com.example.openeer.databinding.ActivityMapBinding
+import com.example.openeer.databinding.ItemMapNoteBinding
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collectLatest
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class MapActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMapBinding
+    private val adapter = MapNotesAdapter()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMapBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // TODO(sprint3): replace with actual map integration
+        binding.toolbar.title = getString(R.string.map_title)
+        binding.toolbar.setNavigationIcon(androidx.appcompat.R.drawable.abc_ic_ab_back_material)
+        binding.toolbar.setNavigationOnClickListener { finish() }
+
+        binding.list.layoutManager = LinearLayoutManager(this)
+        binding.list.adapter = adapter
+
+        val db = AppDatabase.get(this)
+        val repo = NoteRepository(db.noteDao(), db.attachmentDao())
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                repo.geotaggedNotes().collectLatest { notes ->
+                    adapter.submitList(notes)
+                }
+            }
+        }
+    }
+}
+
+private class MapNotesAdapter : ListAdapter<Note, MapNotesAdapter.VH>(DIFF) {
+
+    companion object {
+        private val DATE_FORMAT = SimpleDateFormat("dd MMM yyyy • HH:mm", Locale.getDefault())
+        private val DIFF = object : DiffUtil.ItemCallback<Note>() {
+            override fun areItemsTheSame(a: Note, b: Note) = a.id == b.id
+            override fun areContentsTheSame(a: Note, b: Note) = a == b
+        }
+    }
+
+    class VH(val binding: ItemMapNoteBinding) : RecyclerView.ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: android.view.ViewGroup, viewType: Int): VH {
+        val inflater = android.view.LayoutInflater.from(parent.context)
+        return VH(ItemMapNoteBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: VH, position: Int) {
+        val note = getItem(position)
+        val context = holder.binding.root.context
+        holder.binding.txtTitle.text =
+            note.title?.takeIf { it.isNotBlank() } ?: context.getString(R.string.note_untitled)
+
+        val place = note.placeLabel?.takeIf { it.isNotBlank() }
+        val coordinates = if (note.lat != null && note.lon != null) {
+            context.getString(
+                R.string.map_coordinates_format,
+                note.lat,
+                note.lon
+            )
+        } else {
+            context.getString(R.string.map_location_unknown)
+        }
+        holder.binding.txtPlace.text = place ?: coordinates
+
+        holder.binding.txtUpdated.text = DATE_FORMAT.format(Date(note.updatedAt))
+    }
+}

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        android:theme="@style/ThemeOverlay.Material3.ActionBar"
+        app:titleTextColor="?attr/colorOnSurface" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="16dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_map_note.xml
+++ b/app/src/main/res/layout/item_map_note.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="8dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardElevation="2dp"
+    app:cardUseCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/txtTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="@style/TextAppearance.Material3.TitleMedium"
+            android:textColor="?attr/colorOnSurface"
+            android:textStyle="bold"
+            android:text="@string/note_untitled" />
+
+        <TextView
+            android:id="@+id/txtPlace"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+        <TextView
+            android:id="@+id/txtUpdated"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+            android:textColor="?attr/colorOnSurfaceVariant" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,5 +94,11 @@
     <string name="screenshot_notif_channel_name">Captures d’écran</string>
     <string name="screenshot_notif_channel_desc">Service de capture d’écran</string>
 
+    <!-- Sprint 3: Map skeleton -->
+    <string name="note_untitled">Sans titre</string>
+    <string name="map_title">Carte</string>
+    <string name="map_coordinates_format">(%1\$.4f, %2\$.4f)</string>
+    <string name="map_location_unknown">(Localisation inconnue)</string>
+
 
 </resources>

--- a/app/src/test/java/com/example/openeer/data/NoteDaoGeotaggedTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteDaoGeotaggedTest.kt
@@ -1,0 +1,107 @@
+package com.example.openeer.data
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.example.openeer.rules.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NoteDaoGeotaggedTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    // TODO(sprint3): migrate to shared in-memory helper when available
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private lateinit var db: AppDatabase
+    private lateinit var noteDao: NoteDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        noteDao = db.noteDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun geotaggedNotesFiltersAndOrdersByRecencyAndId() = runTest {
+        val notes = listOf(
+            Note(
+                title = "With coordinates old",
+                body = "",
+                createdAt = 1_000L,
+                updatedAt = 2_000L,
+                lat = 48.8566,
+                lon = 2.3522
+            ),
+            Note(
+                title = "No location",
+                body = "",
+                createdAt = 2_000L,
+                updatedAt = 3_000L
+            ),
+            Note(
+                title = "With place newer",
+                body = "",
+                createdAt = 3_000L,
+                updatedAt = 5_000L,
+                placeLabel = "Paris"
+            ),
+            Note(
+                title = "With coordinates same time",
+                body = "",
+                createdAt = 4_000L,
+                updatedAt = 5_000L,
+                lat = 40.7128,
+                lon = -74.0060
+            ),
+            Note(
+                title = "Partial location",
+                body = "",
+                createdAt = 5_000L,
+                updatedAt = 6_000L,
+                lat = 12.34,
+                lon = null
+            ),
+            Note(
+                title = "Blank place",
+                body = "",
+                createdAt = 6_000L,
+                updatedAt = 7_000L,
+                placeLabel = "   "
+            )
+        )
+
+        val ids = notes.map { noteDao.insert(it) }
+
+        advanceUntilIdle()
+
+        val results = noteDao.geotaggedNotes().first()
+        val resultIds = results.map { it.id }
+
+        val expectedIds = listOf(ids[3], ids[2], ids[0])
+        assertEquals(expectedIds, resultIds)
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room DAO query and repository hook to stream geotagged notes ordered by recency
- introduce a MapActivity skeleton with a toolbar and list adapter showing geotagged note metadata
- create supporting layouts, strings, and Robolectric DAO test coverage for the geotagged list

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Android SDK not present in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5ec05718832da4936898e8a6f6e1