### PR TITLE
Add calendar screen skeleton and ordering query

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,11 @@
             android:exported="false"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
+        <activity
+            android:name=".ui.calendar.CalendarActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+
         <!-- Ancien onboarding : plus de LAUNCHER -->
         <activity
             android:name=".ui.OnboardingActivity"

--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -12,6 +12,9 @@ interface NoteDao {
     @Query("SELECT * FROM notes ORDER BY updatedAt DESC")
     fun getAllFlow(): Flow<List<Note>>
 
+    @Query("SELECT * FROM notes ORDER BY updatedAt DESC, id DESC")
+    fun notesOrderedByDate(): Flow<List<Note>>
+
     // --- Sprint 3: text search ---
     @Query(
         "SELECT * FROM notes " +

--- a/app/src/main/java/com/example/openeer/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteRepository.kt
@@ -10,6 +10,8 @@ class NoteRepository(
 ) {
     val allNotes = noteDao.getAllFlow()
 
+    fun notesByDate() = noteDao.notesOrderedByDate()
+
     // --- Sprint 3: expose text search ---
     fun searchNotes(query: String) = noteDao.searchNotes(query)
 

--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -27,8 +27,9 @@ import com.example.openeer.data.block.BlocksRepository
 import com.example.openeer.databinding.ActivityMainBinding
 import com.example.openeer.ui.capture.CaptureLauncher
 import com.example.openeer.ui.editor.EditorBodyController
-import com.example.openeer.ui.sheets.ChildTextEditorSheet
 import com.example.openeer.ui.map.MapActivity
+import com.example.openeer.ui.sheets.ChildTextEditorSheet
+import com.example.openeer.ui.calendar.CalendarActivity
 import com.example.openeer.ui.util.configureSystemInsets
 import com.example.openeer.ui.util.snackbar
 import com.example.openeer.ui.util.toast
@@ -223,6 +224,9 @@ class MainActivity : AppCompatActivity() {
             editorBody.commitInlineEdit(notePanel.openNoteId)
             notePanel.close()
             b.recycler.post { b.recycler.requestFocus() }
+        }
+        b.btnCalendar.setOnClickListener {
+            startActivity(Intent(this, CalendarActivity::class.java))
         }
         b.btnMap.setOnClickListener {
             startActivity(Intent(this, MapActivity::class.java))

--- a/app/src/main/java/com/example/openeer/ui/calendar/CalendarActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/calendar/CalendarActivity.kt
@@ -1,0 +1,44 @@
+package com.example.openeer.ui.calendar
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.NoteRepository
+import com.example.openeer.databinding.ActivityCalendarBinding
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+
+class CalendarActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityCalendarBinding
+    private val adapter = CalendarAdapter()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityCalendarBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.toolbar.setNavigationOnClickListener { onBackPressedDispatcher.onBackPressed() }
+
+        binding.recycler.layoutManager = LinearLayoutManager(this)
+        binding.recycler.adapter = adapter
+
+        val db = AppDatabase.get(this)
+        val repo = NoteRepository(db.noteDao(), db.attachmentDao())
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                repo.notesByDate().collect { notes ->
+                    // TODO(sprint3): add diffing/interaction when hooking up navigation
+                    adapter.submitNotes(notes)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/openeer/ui/calendar/CalendarAdapter.kt
+++ b/app/src/main/java/com/example/openeer/ui/calendar/CalendarAdapter.kt
@@ -1,0 +1,85 @@
+package com.example.openeer.ui.calendar
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.openeer.R
+import com.example.openeer.data.Note
+import com.example.openeer.databinding.ItemCalendarHeaderBinding
+import com.example.openeer.databinding.ItemCalendarNoteBinding
+import java.text.DateFormat
+import java.util.Date
+import java.util.Locale
+
+class CalendarAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private val rows = mutableListOf<Row>()
+    private val dateFormatter: DateFormat = DateFormat.getDateInstance(DateFormat.MEDIUM, Locale.getDefault())
+
+    fun submitNotes(notes: List<Note>) {
+        rows.clear()
+        var currentHeader: String? = null
+        notes.forEach { note ->
+            val header = formatDate(note.updatedAt)
+            if (header != currentHeader) {
+                rows.add(Row.Header(header))
+                currentHeader = header
+            }
+            rows.add(Row.NoteRow(note))
+        }
+        // TODO(sprint3): Replace notifyDataSetChanged with DiffUtil when UI interactions are added.
+        notifyDataSetChanged()
+    }
+
+    override fun getItemCount(): Int = rows.size
+
+    override fun getItemViewType(position: Int): Int = when (rows[position]) {
+        is Row.Header -> TYPE_HEADER
+        is Row.NoteRow -> TYPE_NOTE
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            TYPE_HEADER -> HeaderViewHolder(ItemCalendarHeaderBinding.inflate(inflater, parent, false))
+            TYPE_NOTE -> NoteViewHolder(ItemCalendarNoteBinding.inflate(inflater, parent, false))
+            else -> throw IllegalArgumentException("Unsupported viewType=$viewType")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is HeaderViewHolder -> holder.bind((rows[position] as Row.Header).label)
+            is NoteViewHolder -> holder.bind((rows[position] as Row.NoteRow).note)
+        }
+    }
+
+    private fun formatDate(timestamp: Long): String = dateFormatter.format(Date(timestamp))
+
+    private sealed class Row {
+        data class Header(val label: String) : Row()
+        data class NoteRow(val note: Note) : Row()
+    }
+
+    private class HeaderViewHolder(
+        private val binding: ItemCalendarHeaderBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(label: String) {
+            binding.txtHeader.text = label
+        }
+    }
+
+    private class NoteViewHolder(
+        private val binding: ItemCalendarNoteBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(note: Note) {
+            binding.txtTitle.text = note.title?.takeIf { it.isNotBlank() }
+                ?: binding.root.context.getString(R.string.note_untitled)
+        }
+    }
+
+    private companion object {
+        const val TYPE_HEADER = 0
+        const val TYPE_NOTE = 1
+    }
+}

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:fitsSystemWindows="true">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorSurface"
+        android:elevation="4dp"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        app:title="@string/calendar_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="16dp"
+        android:clipToPadding="false" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -255,6 +255,25 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
         <LinearLayout
+            android:id="@+id/btnCalendar"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent">
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@android:drawable/ic_menu_my_calendar"
+                android:contentDescription="@string/calendar_title" />
+            <TextView
+                android:text="@string/calendar_title"
+                android:textSize="12sp"
+                android:layout_marginTop="4dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+        <LinearLayout
             android:id="@+id/btnMap"
             android:orientation="vertical"
             android:gravity="center"

--- a/app/src/main/res/layout/item_calendar_header.xml
+++ b/app/src/main/res/layout/item_calendar_header.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/txtHeader"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="16dp"
+    android:paddingBottom="8dp"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+    android:textStyle="bold" />

--- a/app/src/main/res/layout/item_calendar_note.xml
+++ b/app/src/main/res/layout/item_calendar_note.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/txtTitle"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <!-- Sprint 3: Map skeleton -->
     <string name="note_untitled">Sans titre</string>
     <string name="map_title">Carte</string>
+    <string name="calendar_title">Calendrier</string>
     <string name="map_coordinates_format">(%1\$.4f, %2\$.4f)</string>
     <string name="map_location_unknown">(Localisation inconnue)</string>
 

--- a/app/src/test/java/com/example/openeer/data/NoteDaoCalendarOrderingTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteDaoCalendarOrderingTest.kt
@@ -1,0 +1,85 @@
+package com.example.openeer.data
+
+import android.content.Context
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.example.openeer.rules.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NoteDaoCalendarOrderingTest {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val dispatcherRule = MainDispatcherRule()
+
+    private lateinit var db: AppDatabase
+    private lateinit var noteDao: NoteDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        noteDao = db.noteDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun notesOrderedByDateReturnsNewestFirstWithStableTieBreak() = runTest {
+        val notes = listOf(
+            Note(
+                title = "First note",
+                body = "",
+                createdAt = 1_000L,
+                updatedAt = 1_000L
+            ),
+            Note(
+                title = "Second note",
+                body = "",
+                createdAt = 2_000L,
+                updatedAt = 5_000L
+            ),
+            Note(
+                title = "Third note",
+                body = "",
+                createdAt = 3_000L,
+                updatedAt = 5_000L
+            ),
+            Note(
+                title = "Fourth note",
+                body = "",
+                createdAt = 4_000L,
+                updatedAt = 8_000L
+            )
+        )
+
+        val ids = notes.map { noteDao.insert(it) }
+
+        advanceUntilIdle()
+
+        val ordered = noteDao.notesOrderedByDate().first()
+
+        val expectedOrder = listOf(ids[3], ids[2], ids[1], ids[0])
+        assertEquals(expectedOrder, ordered.map { it.id })
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room query to return notes ordered by updated time and expose it from the repository
- introduce a minimal calendar activity, adapter, and layouts to show notes grouped by date
- wire the calendar button in the main screen, register the activity, and cover DAO ordering with a unit test

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de6ea5d99c832da9787b41e23a8d9e