### PR TITLE
Fix note migration test for Room v6 columns

### DIFF
--- a/app/src/main/java/com/example/openeer/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/openeer/data/AppDatabase.kt
@@ -76,24 +76,8 @@ abstract class AppDatabase : RoomDatabase() {
 
         val MIGRATION_5_6 = object : Migration(5, 6) {
             override fun migrate(db: SupportSQLiteDatabase) {
-                var hasTimeBucket = false
-                var hasPlaceLabel = false
-                db.query("PRAGMA table_info(notes)").use { cursor ->
-                    val nameIndex = cursor.getColumnIndex("name")
-                    while (cursor.moveToNext()) {
-                        when (cursor.getString(nameIndex)) {
-                            "timeBucket" -> hasTimeBucket = true
-                            "placeLabel" -> hasPlaceLabel = true
-                        }
-                    }
-                }
-
-                if (!hasTimeBucket) {
-                    db.execSQL("ALTER TABLE notes ADD COLUMN timeBucket TEXT")
-                }
-                if (!hasPlaceLabel) {
-                    db.execSQL("ALTER TABLE notes ADD COLUMN placeLabel TEXT")
-                }
+                db.execSQL("ALTER TABLE notes ADD COLUMN timeBucket INTEGER")
+                db.execSQL("ALTER TABLE notes ADD COLUMN placeLabel TEXT")
             }
         }
 

--- a/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
@@ -1,22 +1,39 @@
 package com.example.openeer.data
 
 import android.content.Context
+import androidx.room.Room
 import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertTrue
+import org.junit.After
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 class NoteMigrationTest {
 
-    @Test
-    fun migrateFrom5To6_addsClassificationColumns() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val dbName = "migration-test"
-        context.deleteDatabase(dbName)
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val dbName = "note-migration-test.db"
 
+    @Before
+    fun setUp() {
+        context.deleteDatabase(dbName)
+    }
+
+    @After
+    fun tearDown() {
+        context.deleteDatabase(dbName)
+    }
+
+    @Test
+    fun migrateFrom5To6_preservesRowsAndAddsNullableColumns() {
+        val helperFactory = FrameworkSQLiteOpenHelperFactory()
         val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
             .name(dbName)
             .callback(object : SupportSQLiteOpenHelper.Callback(5) {
@@ -37,39 +54,67 @@ class NoteMigrationTest {
                         )
                         """.trimIndent()
                     )
+                    db.execSQL(
+                        """
+                        INSERT INTO notes (title, body, createdAt, updatedAt, lat, lon, accuracyM, audioPath, tagsCsv)
+                        VALUES ('Old note', 'Body', 1, 1, NULL, NULL, NULL, NULL, NULL)
+                        """.trimIndent()
+                    )
                 }
 
                 override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-                    // no-op for test
+                    // No-op for the test schema
                 }
             })
             .build()
 
-        val helper = FrameworkSQLiteOpenHelperFactory().create(configuration)
-
+        val helper = helperFactory.create(configuration)
         helper.writableDatabase.close()
+        helper.close()
 
-        val db = helper.writableDatabase
-        AppDatabase.MIGRATION_5_6.migrate(db)
+        val migratedDb = Room.databaseBuilder(context, AppDatabase::class.java, dbName)
+            .addMigrations(AppDatabase.MIGRATION_5_6)
+            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+            .build()
 
-        val columns = mutableMapOf<String, Int>()
-        db.query("PRAGMA table_info(notes)").use { cursor ->
+        val db = migratedDb.openHelper.writableDatabase
+
+        val columns = mutableMapOf<String, Pair<String, Int>>()
+        db.query("PRAGMA table_info('notes')").use { cursor ->
             val nameIndex = cursor.getColumnIndex("name")
+            val typeIndex = cursor.getColumnIndex("type")
             val notNullIndex = cursor.getColumnIndex("notnull")
             while (cursor.moveToNext()) {
                 val name = cursor.getString(nameIndex)
+                val type = cursor.getString(typeIndex)
                 val notNull = cursor.getInt(notNullIndex)
-                columns[name] = notNull
+                columns[name] = type to notNull
             }
         }
 
-        assertTrue(columns.containsKey("timeBucket"))
-        assertEquals(0, columns.getValue("timeBucket"))
-        assertTrue(columns.containsKey("placeLabel"))
-        assertEquals(0, columns.getValue("placeLabel"))
+        val timeBucket = columns["timeBucket"]
+        assertNotNull("timeBucket column missing", timeBucket)
+        assertEquals("INTEGER", timeBucket!!.first.uppercase())
+        assertEquals(0, timeBucket.second)
+
+        val placeLabel = columns["placeLabel"]
+        assertNotNull("placeLabel column missing", placeLabel)
+        assertEquals("TEXT", placeLabel!!.first.uppercase())
+        assertEquals(0, placeLabel.second)
+
+        var rowCount = 0
+        db.query("SELECT id, timeBucket, placeLabel FROM notes").use { cursor ->
+            val timeBucketIndex = cursor.getColumnIndex("timeBucket")
+            val placeLabelIndex = cursor.getColumnIndex("placeLabel")
+            while (cursor.moveToNext()) {
+                rowCount += 1
+                assertTrue(cursor.isNull(timeBucketIndex))
+                assertTrue(cursor.isNull(placeLabelIndex))
+            }
+        }
+        assertEquals(1, rowCount)
 
         db.close()
-        helper.close()
-        context.deleteDatabase(dbName)
+        migratedDb.close()
     }
 }


### PR DESCRIPTION
## Summary
- update the Room v5→v6 migration to add the new nullable columns on notes
- rewrite the Robolectric migration test to exercise the migration and validate schema/data

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: SDK location not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68de96dff0dc832da4579383ad4393fc