### PR TITLE
Fix stable Room migration test

### DIFF
--- a/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
@@ -2,90 +2,77 @@ package com.example.openeer.data
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
 import androidx.sqlite.db.SupportSQLiteDatabase
-import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
+import androidx.test.platform.app.InstrumentationRegistry
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
+private const val DB_NAME = "migration-test.db"
+val V5_CREATE_NOTES_SQL = """
+    CREATE TABLE IF NOT EXISTS notes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        title TEXT,
+        body TEXT,
+        createdAt INTEGER,
+        updatedAt INTEGER,
+        lat REAL,
+        lon REAL,
+        place TEXT,
+        accuracyM REAL,
+        tagsCsv TEXT
+    )
+""".trimIndent()
+
+private const val V5_INSERT_NOTE_SQL = """
+    INSERT INTO notes (id, title, body, createdAt, updatedAt, lat, lon, place, accuracyM, tagsCsv)
+    VALUES (1, 'Legacy title', 'Legacy body', 1, 1, NULL, NULL, NULL, NULL, NULL)
+""".trimIndent()
+
 @RunWith(RobolectricTestRunner::class)
 class NoteMigrationTest {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
-    private val dbName = "migration-test.db"
+    @Rule
+    @JvmField
+    val helper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        AppDatabase::class.java.canonicalName,
+        FrameworkSQLiteOpenHelperFactory()
+    )
 
     @Test
     fun migrateFrom5To6_preservesRowsAndAddsNullableColumns() {
-        val dbFile = context.getDatabasePath(dbName)
-        dbFile.parentFile?.mkdirs()
-        if (dbFile.exists()) {
-            assertTrue(dbFile.delete())
-        }
-
-        val helperFactory = FrameworkSQLiteOpenHelperFactory()
-        val configuration = SupportSQLiteOpenHelper.Configuration.builder(context)
-            .name(dbName)
-            .callback(object : SupportSQLiteOpenHelper.Callback(5) {
-                override fun onCreate(db: SupportSQLiteDatabase) {
-                    db.execSQL(
-                        """
-                        CREATE TABLE IF NOT EXISTS notes (
-                            id INTEGER PRIMARY KEY AUTOINCREMENT,
-                            title TEXT,
-                            body TEXT,
-                            createdAt INTEGER,
-                            updatedAt INTEGER,
-                            lat REAL,
-                            lon REAL,
-                            accuracyM REAL,
-                            audioPath TEXT,
-                            tagsCsv TEXT
-                        )
-                        """.trimIndent()
-                    )
-                    db.execSQL(
-                        """
-                        INSERT INTO notes (title, body, createdAt, updatedAt, lat, lon, accuracyM, audioPath, tagsCsv)
-                        VALUES ('Old note', 'Body', 1, 1, NULL, NULL, NULL, NULL, NULL)
-                        """.trimIndent()
-                    )
-                }
-
-                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {
-                    // no-op for legacy schema creation
-                }
-            })
-            .build()
-
-        var legacyHelper: SupportSQLiteOpenHelper? = null
         var legacyDb: SupportSQLiteDatabase? = null
-        try {
-            legacyHelper = helperFactory.create(configuration)
-            legacyDb = legacyHelper.writableDatabase
-        } finally {
-            legacyDb?.close()
-            legacyHelper?.close()
-        }
-
-        val roomDb = Room.databaseBuilder(context, AppDatabase::class.java, dbName)
-            .addMigrations(AppDatabase.MIGRATION_5_6)
-            .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
-            .build()
-
         var migratedDb: SupportSQLiteDatabase? = null
+        var roomDb: AppDatabase? = null
+
         try {
+            legacyDb = helper.createDatabase(DB_NAME, 5)
+            legacyDb.execSQL(V5_CREATE_NOTES_SQL)
+            legacyDb.execSQL(V5_INSERT_NOTE_SQL)
+            legacyDb.close()
+            legacyDb = null
+
+            val context: Context = ApplicationProvider.getApplicationContext()
+            roomDb = Room.databaseBuilder(context, AppDatabase::class.java, DB_NAME)
+                .openHelperFactory(FrameworkSQLiteOpenHelperFactory())
+                .addMigrations(AppDatabase.MIGRATION_5_6)
+                .build()
+
             migratedDb = roomDb.openHelper.writableDatabase
 
-            val columns = mutableMapOf<String, Pair<String, Int>>()
+            val columns = mutableMapOf<String, Pair<String?, Int>>()
             migratedDb.query("PRAGMA table_info('notes')").use { cursor ->
-                val nameIndex = cursor.getColumnIndex("name")
-                val typeIndex = cursor.getColumnIndex("type")
-                val notNullIndex = cursor.getColumnIndex("notnull")
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val typeIndex = cursor.getColumnIndexOrThrow("type")
+                val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
                 while (cursor.moveToNext()) {
                     val name = cursor.getString(nameIndex)
                     val type = cursor.getString(typeIndex)
@@ -96,23 +83,90 @@ class NoteMigrationTest {
 
             val timeBucket = columns["timeBucket"]
             assertNotNull("timeBucket column missing", timeBucket)
-            assertEquals("INTEGER", timeBucket!!.first.uppercase())
+            assertEquals("INTEGER", timeBucket!!.first?.uppercase())
             assertEquals(0, timeBucket.second)
 
             val placeLabel = columns["placeLabel"]
             assertNotNull("placeLabel column missing", placeLabel)
-            assertEquals("TEXT", placeLabel!!.first.uppercase())
+            assertEquals("TEXT", placeLabel!!.first?.uppercase())
             assertEquals(0, placeLabel.second)
 
-            migratedDb.query("SELECT COUNT(*), timeBucket, placeLabel FROM notes").use { cursor ->
+            migratedDb.query("SELECT COUNT(*) FROM notes").use { cursor ->
                 assertTrue(cursor.moveToFirst())
                 assertEquals(1, cursor.getInt(0))
-                assertTrue(cursor.isNull(1))
-                assertTrue(cursor.isNull(2))
             }
+
+            migratedDb.query("SELECT timeBucket, placeLabel FROM notes WHERE id = 1").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertTrue(cursor.isNull(0))
+                assertTrue(cursor.isNull(1))
+            }
+        } catch (t: Throwable) {
+            val debugDb = migratedDb ?: try {
+                roomDb?.openHelper?.writableDatabase
+            } catch (_: Throwable) {
+                null
+            }
+            try {
+                tryDumpDatabaseState(debugDb)
+            } finally {
+                if (debugDb != null && debugDb !== migratedDb) {
+                    try {
+                        debugDb.close()
+                    } catch (_: Throwable) {
+                    }
+                }
+            }
+            throw t
         } finally {
-            migratedDb?.close()
-            roomDb.close()
+            try {
+                legacyDb?.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                migratedDb?.close()
+            } catch (_: Throwable) {
+            }
+            try {
+                roomDb?.close()
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    private fun tryDumpDatabaseState(db: SupportSQLiteDatabase?) {
+        if (db == null) return
+        try {
+            db.query("PRAGMA table_info('notes')").use { cursor ->
+                val columns = mutableListOf<String>()
+                val nameIndex = cursor.getColumnIndexOrThrow("name")
+                val typeIndex = cursor.getColumnIndexOrThrow("type")
+                val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
+                while (cursor.moveToNext()) {
+                    val name = cursor.getString(nameIndex)
+                    val type = cursor.getString(typeIndex)
+                    val notNull = cursor.getInt(notNullIndex)
+                    columns += "column=$name, type=$type, notnull=$notNull"
+                }
+                System.out.println("PRAGMA table_info('notes'): ${columns.joinToString(prefix = "[", postfix = "]")}")
+            }
+        } catch (_: Throwable) {
+        }
+
+        try {
+            db.query("SELECT * FROM notes LIMIT 1").use { cursor ->
+                val values = mutableListOf<String>()
+                val columnNames = cursor.columnNames
+                if (cursor.moveToFirst()) {
+                    for (index in columnNames.indices) {
+                        val name = columnNames[index]
+                        val value = if (cursor.isNull(index)) "NULL" else cursor.getString(index)
+                        values += "$name=$value"
+                    }
+                }
+                System.out.println("SELECT * FROM notes LIMIT 1: ${values.joinToString(prefix = "[", postfix = "]")}")
+            }
+        } catch (_: Throwable) {
         }
     }
 }


### PR DESCRIPTION
## Summary
- rewrite the Room v5→v6 migration test to use MigrationTestHelper under Robolectric
- seed a deterministic v5 schema row and verify new nullable columns via raw SQL
- add defensive logging and cleanup to aid debugging on failure

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: SDK location not found in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68dea48ed1a0832d99e5aaf984b237a2