### PR TITLE
Refactor note migration test setup

### DIFF
--- a/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
+++ b/app/src/test/java/com/example/openeer/data/NoteMigrationTest.kt
@@ -1,13 +1,12 @@
 package com.example.openeer.data
 
 import androidx.room.testing.MigrationTestHelper
-import androidx.sqlite.db.SupportSQLiteDatabase
-import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
-import org.junit.Rule
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -17,55 +16,65 @@ private const val DB_NAME = "migration-test-db"
 @RunWith(RobolectricTestRunner::class)
 class NoteMigrationTest {
 
-    @Rule
-    @JvmField
-    val helper = MigrationTestHelper(
-        InstrumentationRegistry.getInstrumentation(),
-        AppDatabase::class.java.canonicalName,
-        FrameworkSQLiteOpenHelperFactory()
-    )
+    private lateinit var helper: MigrationTestHelper
+
+    @Before
+    fun setUp() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        helper = MigrationTestHelper(
+            instrumentation,
+            AppDatabase::class.java,
+            emptyList()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        helper.closeWhenFinished(null)
+    }
 
     @Test
     fun migrateFrom5To6_preservesRowsAndAddsNullableColumns() {
-        var legacyDb: SupportSQLiteDatabase? = null
-        var migratedDb: SupportSQLiteDatabase? = null
+        val dbV5 = helper.createDatabase(DB_NAME, 5)
+        dbV5.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS notes(
+              id INTEGER PRIMARY KEY AUTOINCREMENT,
+              title TEXT,
+              body TEXT,
+              createdAt INTEGER NOT NULL,
+              updatedAt INTEGER NOT NULL,
+              lat REAL,
+              lon REAL,
+              place TEXT,
+              accuracyM REAL,
+              tagsCsv TEXT
+            )
+            """.trimIndent()
+        )
+        dbV5.execSQL(
+            """
+            INSERT INTO notes (title, body, createdAt, updatedAt, lat, lon, place, accuracyM, tagsCsv)
+            VALUES ('v5 title', 'v5 body', 111, 222, 48.85, 2.35, 'Paris', 12.3, 'work,voice')
+            """.trimIndent()
+        )
+        dbV5.close()
 
-        try {
-            legacyDb = helper.createDatabase(DB_NAME, 5)
-            legacyDb.execSQL(
-                """
-                CREATE TABLE IF NOT EXISTS notes(
-                  id INTEGER PRIMARY KEY AUTOINCREMENT,
-                  title TEXT,
-                  body TEXT,
-                  createdAt INTEGER NOT NULL,
-                  updatedAt INTEGER NOT NULL,
-                  lat REAL,
-                  lon REAL,
-                  place TEXT,
-                  accuracyM REAL,
-                  tagsCsv TEXT
-                )
-                """.trimIndent()
-            )
-            legacyDb.execSQL(
-                """
-                INSERT INTO notes (title, body, createdAt, updatedAt, lat, lon, place, accuracyM, tagsCsv)
-                VALUES ('v5 title', 'v5 body', 111, 222, 48.85, 2.35, 'Paris', 12.3, 'work,voice')
-                """.trimIndent()
-            )
-            legacyDb.close()
-            legacyDb = null
+        helper.runMigrationsAndValidate(
+            DB_NAME,
+            6,
+            true,
+            AppDatabase.MIGRATION_5_6
+        )
 
-            migratedDb = helper.runMigrationsAndValidate(
-                DB_NAME,
-                6,
-                true,
-                AppDatabase.MIGRATION_5_6
-            )
+        helper.openDatabase(DB_NAME, 6).use { migratedDb ->
+            migratedDb.query("SELECT COUNT(*) AS c FROM notes").use { cursor ->
+                assertTrue(cursor.moveToFirst())
+                assertEquals(1, cursor.getInt(0))
+            }
 
             val columns = mutableMapOf<String, Pair<String?, Int>>()
-            migratedDb.query("PRAGMA table_info('notes')").use { cursor ->
+            migratedDb.query("PRAGMA table_info(notes)").use { cursor ->
                 val nameIndex = cursor.getColumnIndexOrThrow("name")
                 val typeIndex = cursor.getColumnIndexOrThrow("type")
                 val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
@@ -87,11 +96,6 @@ class NoteMigrationTest {
             assertEquals("TEXT", placeLabel!!.first?.uppercase())
             assertEquals(0, placeLabel.second)
 
-            migratedDb.query("SELECT COUNT(*) FROM notes").use { cursor ->
-                assertTrue(cursor.moveToFirst())
-                assertEquals(1, cursor.getInt(0))
-            }
-
             migratedDb.query(
                 """
                 SELECT title, body, createdAt, updatedAt, timeBucket, placeLabel
@@ -107,54 +111,6 @@ class NoteMigrationTest {
                 assertTrue(cursor.isNull(4))
                 assertTrue(cursor.isNull(5))
             }
-        } catch (t: Throwable) {
-            tryDumpDatabaseState(migratedDb)
-            throw t
-        } finally {
-            try {
-                legacyDb?.close()
-            } catch (_: Throwable) {
-            }
-            try {
-                migratedDb?.close()
-            } catch (_: Throwable) {
-            }
-        }
-    }
-
-    private fun tryDumpDatabaseState(db: SupportSQLiteDatabase?) {
-        if (db == null) return
-        try {
-            db.query("PRAGMA table_info('notes')").use { cursor ->
-                val columns = mutableListOf<String>()
-                val nameIndex = cursor.getColumnIndexOrThrow("name")
-                val typeIndex = cursor.getColumnIndexOrThrow("type")
-                val notNullIndex = cursor.getColumnIndexOrThrow("notnull")
-                while (cursor.moveToNext()) {
-                    val name = cursor.getString(nameIndex)
-                    val type = cursor.getString(typeIndex)
-                    val notNull = cursor.getInt(notNullIndex)
-                    columns += "column=$name, type=$type, notnull=$notNull"
-                }
-                System.out.println("PRAGMA table_info('notes'): ${columns.joinToString(prefix = "[", postfix = "]")}")
-            }
-        } catch (_: Throwable) {
-        }
-
-        try {
-            db.query("SELECT * FROM notes LIMIT 1").use { cursor ->
-                val values = mutableListOf<String>()
-                val columnNames = cursor.columnNames
-                if (cursor.moveToFirst()) {
-                    for (index in columnNames.indices) {
-                        val name = columnNames[index]
-                        val value = if (cursor.isNull(index)) "NULL" else cursor.getString(index)
-                        values += "$name=$value"
-                    }
-                }
-                System.out.println("SELECT * FROM notes LIMIT 1: ${values.joinToString(prefix = "[", postfix = "]")}")
-            }
-        } catch (_: Throwable) {
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize the migration test helper with the instrumentation-aware constructor
- inline the version 5 schema creation and seed data so the migration test no longer reads files
- reopen the migrated database to validate row retention and new nullable columns

## Testing
- ./gradlew :app:testDebugUnitTest *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df659a5c98832d97272ff9d08c1900