### PR TITLE
feat(import-ui): add Import button placeholder in bottom bar (no logic yet)

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -235,6 +235,10 @@ class MainActivity : AppCompatActivity() {
             b.root.snackbar("Carte/Itinéraire — bientôt disponible")
         }
 
+        b.btnImport.setOnClickListener {
+            toast("Import bientôt…")
+        }
+
         // Clic sur le corps = édition inline
         b.txtBodyDetail.setOnClickListener {
             lifecycleScope.launch {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -274,6 +274,27 @@
                 android:layout_height="wrap_content" />
         </LinearLayout>
         <LinearLayout
+            android:id="@+id/btnImport"
+            android:orientation="vertical"
+            android:gravity="center"
+            android:focusable="true"
+            android:importantForAccessibility="yes"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent">
+            <ImageView
+                android:layout_width="32dp"
+                android:layout_height="32dp"
+                android:src="@android:drawable/ic_menu_add"
+                android:contentDescription="Importer" />
+            <TextView
+                android:text="Importer"
+                android:textSize="12sp"
+                android:layout_marginTop="4dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+        </LinearLayout>
+        <LinearLayout
             android:id="@+id/btnMenu"
             android:orientation="vertical"
             android:gravity="center"


### PR DESCRIPTION
## Summary
- add a new Import button to the home screen bottom bar aligned with existing actions
- hook the Import button to show a placeholder toast while future work is pending

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5343fc4d0832dafe087e4e60f5706