### PR TITLE
feat: wire Import button to SAF picker

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -87,6 +87,24 @@ class MainActivity : AppCompatActivity() {
             if (!ok) toast("Permission micro refusée", Toast.LENGTH_LONG)
         }
 
+    private val importLauncher =
+        registerForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+            if (uris.isEmpty()) return@registerForActivityResult
+
+            uris.forEach { uri ->
+                try {
+                    contentResolver.takePersistableUriPermission(
+                        uri,
+                        Intent.FLAG_GRANT_READ_URI_PERMISSION
+                    )
+                } catch (_: SecurityException) {
+                    // Ignore if permission already granted or persist not possible
+                }
+            }
+
+            toast("${uris.size} fichier(s) sélectionné(s) — import à venir")
+        }
+
     private fun hasRecordPerm(): Boolean =
         ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) ==
                 PackageManager.PERMISSION_GRANTED
@@ -236,7 +254,15 @@ class MainActivity : AppCompatActivity() {
         }
 
         b.btnImport.setOnClickListener {
-            toast("Import bientôt…")
+            importLauncher.launch(
+                arrayOf(
+                    "image/*",
+                    "video/*",
+                    "audio/*",
+                    "text/plain",
+                    "application/pdf"
+                )
+            )
         }
 
         // Clic sur le corps = édition inline


### PR DESCRIPTION
## Summary
- register an ActivityResultLauncher using OpenMultipleDocuments to support multi-file selection
- persist SAF read permissions for selected URIs and show a toast with the selection count
- trigger the SAF picker from the Import button with the allowed MIME types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e538e28b3c832db3192aad24c89db8