### PR TITLE
Normalize safe defaults for import metadata

### DIFF
--- a/app/src/main/java/com/example/openeer/imports/FileCopy.kt
+++ b/app/src/main/java/com/example/openeer/imports/FileCopy.kt
@@ -10,6 +10,13 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 object FileCopy {
+    fun guessNameFromUri(resolver: ContentResolver, uri: Uri): String? {
+        resolver.query(uri, arrayOf("_display_name"), null, null, null)?.use { c ->
+            if (c.moveToFirst()) return c.getString(0)
+        }
+        return uri.lastPathSegment?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+    }
+
     suspend fun toAppSandbox(
         context: Context,
         resolver: ContentResolver,


### PR DESCRIPTION
## Summary
- normalize imported display names and MIME types to safe defaults before invoking repository helpers
- reuse a content-resolver helper to guess file names from URIs when the source metadata is missing

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: local Android SDK is unavailable in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e544cc34f4832d90bac9e625d290a6