### PR TITLE
Fix audio/text pile increments on import events

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -413,13 +413,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun incrementPileCount(kind: MediaKind) {
         if (notePanel.openNoteId == null) return
-        val updated = when (kind) {
-            MediaKind.IMAGE, MediaKind.VIDEO -> lastPileCounts.copy(photos = lastPileCounts.photos + 1)
-            MediaKind.AUDIO -> lastPileCounts.copy(audios = lastPileCounts.audios + 1)
-            MediaKind.TEXT -> lastPileCounts.copy(textes = lastPileCounts.textes + 1)
-            MediaKind.PDF, MediaKind.UNKNOWN -> lastPileCounts.copy(files = lastPileCounts.files + 1)
-        }
-        applyPileCounts(updated)
+
+        applyPileCounts(lastPileCounts.increment(kind))
     }
 
     private fun onChildBlockSaved(noteId: Long, blockId: Long?, message: String) {

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -25,6 +25,7 @@ import com.example.openeer.data.block.BlockEntity
 import com.example.openeer.data.block.BlockType
 import com.example.openeer.data.block.BlocksRepository
 import com.example.openeer.databinding.ActivityMainBinding
+import com.example.openeer.imports.MediaKind
 import com.example.openeer.ui.SimplePlayer
 import com.example.openeer.ui.formatMeta
 import com.example.openeer.ui.panel.blocks.BlockRenderers
@@ -44,7 +45,14 @@ data class PileCounts(
     val audios: Int = 0,
     val textes: Int = 0,
     val files: Int = 0,
-)
+) {
+    fun increment(kind: MediaKind): PileCounts = when (kind) {
+        MediaKind.IMAGE, MediaKind.VIDEO -> copy(photos = photos + 1)
+        MediaKind.AUDIO -> copy(audios = audios + 1)
+        MediaKind.TEXT -> copy(textes = textes + 1)
+        MediaKind.PDF, MediaKind.UNKNOWN -> copy(files = files + 1)
+    }
+}
 
 class NotePanelController(
     private val activity: AppCompatActivity,


### PR DESCRIPTION
## Summary
- centralize the MediaKind-to-pile mapping inside `PileCounts.increment`
- update the import event handler to reuse the shared helper when bumping counters

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e554cfa1a4832dbe34c90b4cd794b2