### PR TITLE
feat: implement repository-level note merge logic

### DIFF
--- a/app/src/main/java/com/example/openeer/audio/RecorderService.kt
+++ b/app/src/main/java/com/example/openeer/audio/RecorderService.kt
@@ -44,13 +44,14 @@ class RecorderService : Service() {
     override fun onCreate() {
         super.onCreate()
         val db = AppDatabase.get(this)
-        repo = NoteRepository(db.noteDao(), db.attachmentDao())
         // ✅ Injection du linkDao pour activer la création des liens AUDIO→TEXTE
-        blocksRepo = BlocksRepository(
+        val blocks = BlocksRepository(
             blockDao = db.blockDao(),
             noteDao  = null,
             linkDao  = db.blockLinkDao()
         )
+        repo = NoteRepository(db.noteDao(), db.attachmentDao(), blocks)
+        blocksRepo = blocks
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
@@ -33,6 +33,9 @@ interface BlockDao {
     @Query("UPDATE blocks SET position = :position WHERE id = :id AND noteId = :noteId")
     suspend fun updatePosition(id: Long, noteId: Long, position: Int)
 
+    @Query("UPDATE blocks SET noteId = :targetNoteId WHERE noteId = :sourceNoteId")
+    suspend fun updateNoteIdForBlocks(sourceNoteId: Long, targetNoteId: Long)
+
     // ✅ Utilisée par BlocksRepository.updateAudioTranscription(...)
     @Query("UPDATE blocks SET text = :newText, updatedAt = :updatedAt WHERE id = :blockId")
     suspend fun updateTranscription(blockId: Long, newText: String, updatedAt: Long)

--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -28,6 +28,12 @@ class BlocksRepository(
         blockDao.getById(blockId)
     }
 
+    suspend fun reassignBlocksToNote(sourceNoteId: Long, targetNoteId: Long) {
+        withContext(io) {
+            blockDao.updateNoteIdForBlocks(sourceNoteId, targetNoteId)
+        }
+    }
+
     private suspend fun insert(noteId: Long, template: BlockEntity): Long =
         withContext(io) { blockDao.insertAtEnd(noteId, template) }
 

--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -58,7 +58,14 @@ class MainActivity : AppCompatActivity() {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 val db = AppDatabase.get(this@MainActivity)
-                return NotesVm(NoteRepository(db.noteDao(), db.attachmentDao())) as T
+                val blocksRepo = BlocksRepository(
+                    blockDao = db.blockDao(),
+                    noteDao = db.noteDao(),
+                    linkDao = db.blockLinkDao()
+                )
+                return NotesVm(
+                    NoteRepository(db.noteDao(), db.attachmentDao(), blocksRepo)
+                ) as T
             }
         }
     }
@@ -71,7 +78,7 @@ class MainActivity : AppCompatActivity() {
     // Repos
     private val repo: NoteRepository by lazy {
         val db = AppDatabase.get(this)
-        NoteRepository(db.noteDao(), db.attachmentDao())
+        NoteRepository(db.noteDao(), db.attachmentDao(), blocksRepo)
     }
     private val blocksRepo: BlocksRepository by lazy {
         val db = AppDatabase.get(this)

--- a/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotePanelController.kt
@@ -69,7 +69,7 @@ class NotePanelController(
 
     private val repo: NoteRepository by lazy {
         val db = AppDatabase.get(activity)
-        NoteRepository(db.noteDao(), db.attachmentDao())
+        NoteRepository(db.noteDao(), db.attachmentDao(), blocksRepo)
     }
 
     var openNoteId: Long? = null


### PR DESCRIPTION
## Summary
- add a mergeNotes workflow in NoteRepository that records merge maps and reassigns blocks
- expose block reassignment helper in BlocksRepository/BlockDao
- inject BlocksRepository into NoteRepository creation sites so merge support is wired up

## Testing
- ./gradlew test *(fails: Android SDK path not configured in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e575c477e4832d8db5b68c95331e95