### PR TITLE
feat(library): enable merging notes from multi-selection

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -50,6 +50,10 @@ import androidx.core.view.isGone
 
 class MainActivity : AppCompatActivity() {
 
+    companion object {
+        const val EXTRA_OPEN_NOTE_ID = "com.example.openeer.extra.OPEN_NOTE_ID"
+    }
+
     private lateinit var b: ActivityMainBinding
 
     // VM / liste
@@ -191,6 +195,8 @@ class MainActivity : AppCompatActivity() {
             onAppendLive = { body -> notePanel.onAppendLive(body) },
             onReplaceFinal = { body, addNewline -> notePanel.onReplaceFinal(body, addNewline) }
         )
+
+        handleOpenNoteIntent(intent)
 
         // Geste micro
         b.btnMicBar.setOnTouchListener { v, ev ->
@@ -475,6 +481,20 @@ class MainActivity : AppCompatActivity() {
                 }
                 counts[i].text = (countFromPiles ?: fallbackCount).toString()
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleOpenNoteIntent(intent)
+    }
+
+    private fun handleOpenNoteIntent(intent: Intent?) {
+        val targetId = intent?.getLongExtra(EXTRA_OPEN_NOTE_ID, -1L) ?: -1L
+        if (targetId > 0) {
+            notePanel.open(targetId)
+            intent?.removeExtra(EXTRA_OPEN_NOTE_ID)
         }
     }
 

--- a/app/src/main/java/com/example/openeer/ui/NotesAdapter.kt
+++ b/app/src/main/java/com/example/openeer/ui/NotesAdapter.kt
@@ -1,11 +1,12 @@
 package com.example.openeer.ui
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.example.openeer.R
 import com.example.openeer.data.Note
 import com.example.openeer.databinding.ItemNoteBinding
 import com.example.openeer.ui.formatMeta
@@ -14,6 +15,12 @@ class NotesAdapter(
     private val onClick: (Note) -> Unit,
     private val onLongClick: (Note) -> Unit
 ) : ListAdapter<Note, NotesAdapter.VH>(DIFF) {
+
+    var selectedIds: Set<Long> = emptySet()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
 
     companion object {
         private val DIFF = object : DiffUtil.ItemCallback<Note>() {
@@ -30,12 +37,26 @@ class NotesAdapter(
 
     override fun onBindViewHolder(h: VH, pos: Int) {
         val n = getItem(pos)
+        val ctx = h.b.root.context
+
         h.b.titleOrBody.text =
             n.title?.takeIf { it.isNotBlank() }
-                ?: n.body.ifBlank { "(vide)" }.take(80)
+                ?: n.body.ifBlank { ctx.getString(R.string.library_merge_untitled_placeholder) }.take(80)
 
-        h.b.meta.text = n.formatMeta()
-        h.b.iconReminder.visibility = View.GONE
+        val meta = n.formatMeta()
+        h.b.meta.text = if (n.isMerged) {
+            ctx.getString(R.string.library_note_meta_merged, meta)
+        } else {
+            meta
+        }
+        h.b.iconReminder.isVisible = false
+
+        val isSelected = selectedIds.contains(n.id)
+        h.b.root.isActivated = isSelected
+        h.b.root.isSelected = isSelected
+
+        val baseAlpha = if (n.isMerged) 0.45f else 1f
+        h.b.root.alpha = if (isSelected) 1f else baseAlpha
 
         h.b.root.setOnClickListener { onClick(n) }
         h.b.root.setOnLongClickListener { onLongClick(n); true }

--- a/app/src/main/java/com/example/openeer/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/openeer/ui/library/LibraryViewModel.kt
@@ -2,15 +2,20 @@ package com.example.openeer.ui.library
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.openeer.data.Note
 import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.Note
+import com.example.openeer.data.NoteRepository
+import com.example.openeer.data.block.BlocksRepository
 import com.example.openeer.data.search.SearchRepository
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class LibraryViewModel(
-    private val repo: SearchRepository
+    private val repo: SearchRepository,
+    private val noteRepo: NoteRepository
 ) : ViewModel() {
 
     private val _items = MutableStateFlow<List<Note>>(emptyList())
@@ -19,7 +24,10 @@ class LibraryViewModel(
     private val _loading = MutableStateFlow(false)
     val loading: StateFlow<Boolean> = _loading
 
+    private var lastQuery: String = ""
+
     fun search(q: String) {
+        lastQuery = q
         viewModelScope.launch {
             _loading.value = true
             try {
@@ -30,13 +38,29 @@ class LibraryViewModel(
         }
     }
 
+    fun refresh() {
+        search(lastQuery)
+    }
+
+    suspend fun mergeNotes(sourceIds: List<Long>, targetId: Long): NoteRepository.MergeResult {
+        return withContext(Dispatchers.IO) {
+            noteRepo.mergeNotes(sourceIds, targetId)
+        }
+    }
+
     companion object {
         fun create(db: AppDatabase): LibraryViewModel {
             val repo = SearchRepository(
                 searchDao = db.searchDao(),
                 tagDao = db.tagDao()
             )
-            return LibraryViewModel(repo)
+            val blocksRepo = BlocksRepository(
+                blockDao = db.blockDao(),
+                noteDao = db.noteDao(),
+                linkDao = db.blockLinkDao()
+            )
+            val noteRepo = NoteRepository(db.noteDao(), db.attachmentDao(), blocksRepo)
+            return LibraryViewModel(repo, noteRepo)
         }
     }
 }

--- a/app/src/main/res/drawable/bg_note_item.xml
+++ b/app/src/main/res/drawable/bg_note_item.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_activated="true">
+        <shape android:shape="rectangle">
+            <solid android:color="?attr/colorSecondaryContainer" />
+        </shape>
+    </item>
+    <item android:state_selected="true">
+        <shape android:shape="rectangle">
+            <solid android:color="?attr/colorSecondaryContainer" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/item_note.xml
+++ b/app/src/main/res/layout/item_note.xml
@@ -5,7 +5,8 @@
     android:padding="12dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
+    android:background="@drawable/bg_note_item"
+    android:foreground="?attr/selectableItemBackgroundBorderless"
     android:clickable="true"
     android:focusable="true">
 

--- a/app/src/main/res/menu/menu_library_selection.xml
+++ b/app/src/main/res/menu/menu_library_selection.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_merge"
+        android:title="@string/library_action_merge"
+        android:icon="@android:drawable/ic_menu_upload"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,5 +98,18 @@
     <string name="zoom_out">Zoom arrière</string>
     <string name="recenter">Recentrer</string>
 
+    <string name="library_action_merge">Fusionner…</string>
+    <string name="library_merge_dialog_title">Choisir la note cible</string>
+    <string name="library_merge_dialog_message">Sélectionnez la note à conserver dans la fusion.</string>
+    <string name="library_merge_positive">Fusionner</string>
+    <string name="library_merge_in_progress">Fusion en cours…</string>
+    <string name="library_merge_success">Fusion réussie</string>
+    <string name="library_merge_partial">Fusion partielle (%1$d/%2$d)</string>
+    <string name="library_merge_failed">Fusion impossible</string>
+    <string name="library_selection_count">%1$d sélectionnée(s)</string>
+    <string name="library_note_meta_merged">%1$s • Fusionnée</string>
+    <string name="library_merge_untitled_placeholder">(vide)</string>
+    <string name="library_note_already_merged">Note déjà fusionnée</string>
+
 
 </resources>


### PR DESCRIPTION
## Summary
- enable contextual multi-selection in the library list with a "Fusionner…" action
- add a target-picking dialog and call NoteRepository.mergeNotes for non-destructive merges
- refresh the list, grey merged notes, and open the chosen target note in MainActivity

## Testing
- ./gradlew lintDebug *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57887bddc832d8be09003afcffe74