### PR TITLE
feat: add merge flow from note panel overflow menu

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/MainActivity.kt
@@ -169,6 +169,7 @@ class MainActivity : AppCompatActivity() {
 
         // Note panel
         notePanel = NotePanelController(this, b)
+        notePanel.attachTopBubble(topBubble)
         notePanel.onPileCountsChanged = { counts -> applyPileCounts(counts) }
         lifecycleScope.launch {
             notePanel.observePileUi().collectLatest { piles ->

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -71,7 +71,8 @@
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical">
             <ImageView
                 android:id="@+id/btnBack"
                 android:src="@android:drawable/ic_media_previous"
@@ -91,6 +92,15 @@
                 android:background="?attr/selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true" />
+            <ImageButton
+                android:id="@+id/btnNoteMenu"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:padding="4dp"
+                android:contentDescription="Plus d’actions"
+                android:src="@android:drawable/ic_menu_more"
+                android:visibility="visible" />
         </LinearLayout>
 
         <!-- Corps défilant -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -111,5 +111,12 @@
     <string name="library_merge_untitled_placeholder">(vide)</string>
     <string name="library_note_already_merged">Note déjà fusionnée</string>
 
+    <string name="note_menu_merge_with">Fusionner avec…</string>
+    <string name="note_merge_dialog_title">Fusionner avec…</string>
+    <string name="note_merge_in_progress">Fusion en cours…</string>
+    <string name="note_merge_done">Fusion terminée</string>
+    <string name="note_merge_failed">Fusion impossible</string>
+    <string name="note_merge_empty">Aucune autre note disponible</string>
+
 
 </resources>


### PR DESCRIPTION
## Summary
- add an overflow action in the note panel to launch “Fusionner avec…”
- display a multi-select picker to choose source notes and show progress via the top bubble while merging
- notify and filter the library list so merged source notes disappear when the merge completes

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e57c20a380832d9794daa568ab0e0f