### PR TITLE
feat: add undo workflow for note merges

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -57,4 +57,10 @@ interface NoteDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMergeMaps(maps: List<NoteMergeMapEntity>)
+
+    @Query("UPDATE notes SET isMerged = 0 WHERE id IN (:sourceIds)")
+    suspend fun unmarkMerged(sourceIds: List<Long>)
+
+    @Query("DELETE FROM note_merge_map WHERE noteId IN (:sourceIds)")
+    suspend fun deleteMergeMaps(sourceIds: List<Long>)
 }

--- a/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
@@ -36,6 +36,12 @@ interface BlockDao {
     @Query("UPDATE blocks SET noteId = :targetNoteId WHERE noteId = :sourceNoteId")
     suspend fun updateNoteIdForBlocks(sourceNoteId: Long, targetNoteId: Long)
 
+    @Query("SELECT id FROM blocks WHERE noteId = :noteId ORDER BY position ASC")
+    suspend fun getBlockIdsForNote(noteId: Long): List<Long>
+
+    @Query("UPDATE blocks SET noteId = :targetNoteId WHERE id IN (:blockIds)")
+    suspend fun updateNoteIdForBlockIds(blockIds: List<Long>, targetNoteId: Long)
+
     // ✅ Utilisée par BlocksRepository.updateAudioTranscription(...)
     @Query("UPDATE blocks SET text = :newText, updatedAt = :updatedAt WHERE id = :blockId")
     suspend fun updateTranscription(blockId: Long, newText: String, updatedAt: Long)

--- a/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlocksRepository.kt
@@ -34,6 +34,19 @@ class BlocksRepository(
         }
     }
 
+    suspend fun getBlockIds(noteId: Long): List<Long> = withContext(io) {
+        blockDao.getBlockIdsForNote(noteId)
+    }
+
+    suspend fun reassignBlocksByIds(blockIds: List<Long>, targetNoteId: Long) {
+        if (blockIds.isEmpty()) return
+        withContext(io) {
+            blockIds.chunked(900).forEach { chunk ->
+                blockDao.updateNoteIdForBlockIds(chunk, targetNoteId)
+            }
+        }
+    }
+
     private suspend fun insert(noteId: Long, template: BlockEntity): Long =
         withContext(io) { blockDao.insertAtEnd(noteId, template) }
 

--- a/app/src/main/java/com/example/openeer/ui/library/LibraryViewModel.kt
+++ b/app/src/main/java/com/example/openeer/ui/library/LibraryViewModel.kt
@@ -48,6 +48,12 @@ class LibraryViewModel(
         }
     }
 
+    suspend fun undoMerge(tx: NoteRepository.MergeTransaction): Boolean {
+        return withContext(Dispatchers.IO) {
+            noteRepo.undoMerge(tx)
+        }
+    }
+
     companion object {
         fun create(db: AppDatabase): LibraryViewModel {
             val repo = SearchRepository(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,9 @@
     <string name="library_merge_success">Fusion réussie</string>
     <string name="library_merge_partial">Fusion partielle (%1$d/%2$d)</string>
     <string name="library_merge_failed">Fusion impossible</string>
+    <string name="library_merge_success_with_count">Fusion réussie (%1$d/%2$d)</string>
+    <string name="library_merge_undo_success">Fusion annulée</string>
+    <string name="library_merge_undo_failed">Annulation impossible</string>
     <string name="library_selection_count">%1$d sélectionnée(s)</string>
     <string name="library_note_meta_merged">%1$s • Fusionnée</string>
     <string name="library_merge_untitled_placeholder">(vide)</string>
@@ -117,6 +120,7 @@
     <string name="note_merge_done">Fusion terminée</string>
     <string name="note_merge_failed">Fusion impossible</string>
     <string name="note_merge_empty">Aucune autre note disponible</string>
+    <string name="action_undo">Annuler</string>
 
 
 </resources>


### PR DESCRIPTION
## Summary
- extend note merge flow with transaction snapshots to support undo and DAO helpers
- surface an undo snackbar after merges in the library and note panel experiences
- localize new undo messaging strings and refresh the library after undo actions

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68e602830aec832dbea4cd94b8737959