### PR TITLE
Fix merge result naming consistency

### DIFF
--- a/app/src/main/java/com/example/openeer/data/MergeResultExtensions.kt
+++ b/app/src/main/java/com/example/openeer/data/MergeResultExtensions.kt
@@ -1,0 +1,9 @@
+package com.example.openeer.data
+
+import com.example.openeer.data.NoteRepository.MergeResult
+
+val MergeResult.merged: Int
+    get() = this.mergedCount
+
+val MergeResult.skipped: Int
+    get() = this.skippedCount

--- a/app/src/main/java/com/example/openeer/data/NoteRepository.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteRepository.kt
@@ -129,7 +129,7 @@ class NoteRepository(
         }
 
         return MergeResult(
-            merged = merged,
+            mergedCount = merged,
             skippedCount = skipped,
             total = validSources.size,
             mergedSourceIds = mergedSources.toList(),


### PR DESCRIPTION
## Summary
- align `MergeResult` construction with the `mergedCount`/`skippedCount`/`total` parameter names
- add compatibility extensions exposing the legacy `merged`/`skipped` accessors

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e60b234520832dbdde66b55a9e2f58