### PR TITLE
Add Room note merge log table and migrations

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -63,4 +63,13 @@ interface NoteDao {
 
     @Query("DELETE FROM note_merge_map WHERE noteId IN (:sourceIds)")
     suspend fun deleteMergeMaps(sourceIds: List<Long>)
+
+    @Insert
+    suspend fun insertMergeLog(entry: NoteMergeLogEntity): Long
+
+    @Query("SELECT * FROM note_merge_log WHERE id = :id LIMIT 1")
+    suspend fun getMergeLogById(id: Long): NoteMergeLogEntity?
+
+    @Query("DELETE FROM note_merge_log WHERE id = :id")
+    suspend fun deleteMergeLog(id: Long)
 }

--- a/app/src/main/java/com/example/openeer/data/NoteMergeLogEntity.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteMergeLogEntity.kt
@@ -1,0 +1,17 @@
+package com.example.openeer.data
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "note_merge_log",
+    indices = [Index("sourceId"), Index("targetId")]
+)
+data class NoteMergeLogEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val sourceId: Long,
+    val targetId: Long,
+    val snapshotJson: String,
+    val createdAt: Long
+)


### PR DESCRIPTION
## Summary
- add a Room entity for persisting note merge log snapshots
- expose DAO helpers to manage merge log entries
- create and register the 10->11 migration to install the note_merge_log table

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e616d4348c832db62c6d6caa40f4ac