### PR TITLE
Add block snapshot models and hashing helpers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,8 @@ dependencies {
     // MapLibre GL Android (API v12, simple et stable)
     implementation("org.maplibre.gl:android-sdk:12.0.0")
 
+    implementation("com.google.code.gson:gson:2.11.0")
+
 
 
     // Tests

--- a/app/src/main/java/com/example/openeer/data/merge/Snapshots.kt
+++ b/app/src/main/java/com/example/openeer/data/merge/Snapshots.kt
@@ -1,0 +1,72 @@
+package com.example.openeer.data.merge
+
+import com.example.openeer.data.block.BlockEntity
+import com.google.gson.Gson
+import java.security.MessageDigest
+
+private val snapshotGson: Gson by lazy { Gson() }
+
+private fun ByteArray.toHexString(): String = joinToString(separator = "") { byte ->
+    "%02x".format(byte)
+}
+
+data class BlockSnapshot(
+    val id: Long,
+    val noteIdSource: Long,
+    val type: String,
+    val groupId: String?,
+    val createdAt: Long,
+    val updatedAt: Long,
+    val rawJson: String,
+    val hash: String
+)
+
+data class MergeSnapshot(
+    val sourceId: Long,
+    val targetId: Long,
+    val blocks: List<BlockSnapshot>
+)
+
+fun computeBlockHash(block: BlockEntity): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    val payload = buildString {
+        append(block.type.name)
+        append('|')
+        append(block.text.orEmpty())
+        append('|')
+        append(block.mediaUri.orEmpty())
+        append('|')
+        append(block.mimeType.orEmpty())
+        append('|')
+        append(block.durationMs?.toString().orEmpty())
+        append('|')
+        append(block.width?.toString().orEmpty())
+        append('|')
+        append(block.height?.toString().orEmpty())
+        append('|')
+        append(block.lat?.toString().orEmpty())
+        append('|')
+        append(block.lon?.toString().orEmpty())
+        append('|')
+        append(block.placeName.orEmpty())
+        append('|')
+        append(block.routeJson.orEmpty())
+        append('|')
+        append(block.extra.orEmpty())
+    }
+    return digest.digest(payload.toByteArray(Charsets.UTF_8)).toHexString()
+}
+
+fun toSnapshot(sourceNoteId: Long, block: BlockEntity): BlockSnapshot {
+    val raw = snapshotGson.toJson(block)
+    return BlockSnapshot(
+        id = block.id,
+        noteIdSource = sourceNoteId,
+        type = block.type.name,
+        groupId = block.groupId,
+        createdAt = block.createdAt,
+        updatedAt = block.updatedAt,
+        rawJson = raw,
+        hash = computeBlockHash(block)
+    )
+}


### PR DESCRIPTION
## Summary
- add Gson dependency for serialising block entities
- introduce reusable BlockSnapshot and MergeSnapshot models with hash generation helpers

## Testing
- ./gradlew test --console=plain (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68e61a006108832d948908d3e5bd1331