### PR TITLE
Add undo merge recovery workflow

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -61,8 +61,14 @@ interface NoteDao {
     @Query("UPDATE notes SET isMerged = 0 WHERE id IN (:sourceIds)")
     suspend fun unmarkMerged(sourceIds: List<Long>)
 
+    @Query("UPDATE notes SET isMerged = :isMerged WHERE id = :noteId")
+    suspend fun updateIsMerged(noteId: Long, isMerged: Boolean)
+
     @Query("DELETE FROM note_merge_map WHERE noteId IN (:sourceIds)")
     suspend fun deleteMergeMaps(sourceIds: List<Long>)
+
+    @Query("DELETE FROM note_merge_map WHERE noteId = :sourceId")
+    suspend fun deleteMergeMapForSource(sourceId: Long)
 
     @Insert
     suspend fun insertMergeLog(entry: NoteMergeLogEntity): Long


### PR DESCRIPTION
## Summary
- add DAO helpers to toggle merge state and remove merge maps for a source note
- extend BlocksRepository so blocks can be recreated from stored snapshots
- implement undoMergeById in NoteRepository to restore or reassign merged blocks

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e621d31c20832dac50b22275a8af69