### PR TITLE
feat: add merge history screen with undo access

### DIFF
--- a/app/src/main/java/com/example/openeer/data/NoteDao.kt
+++ b/app/src/main/java/com/example/openeer/data/NoteDao.kt
@@ -3,6 +3,15 @@ package com.example.openeer.data
 import androidx.room.*
 import kotlinx.coroutines.flow.Flow
 
+data class MergeLogUiRow(
+    val id: Long,
+    val sourceId: Long,
+    val sourceTitle: String?,
+    val targetId: Long,
+    val targetTitle: String?,
+    val createdAt: Long
+)
+
 @Dao
 interface NoteDao {
     @Insert
@@ -78,4 +87,15 @@ interface NoteDao {
 
     @Query("DELETE FROM note_merge_log WHERE id = :id")
     suspend fun deleteMergeLog(id: Long)
+
+    @Query(
+        """
+        SELECT l.id, l.sourceId, s.title AS sourceTitle, l.targetId, t.title AS targetTitle, l.createdAt
+        FROM note_merge_log l
+        LEFT JOIN notes s ON s.id = l.sourceId
+        LEFT JOIN notes t ON t.id = l.targetId
+        ORDER BY l.createdAt DESC
+        """
+    )
+    suspend fun listMergeLogsUi(): List<MergeLogUiRow>
 }

--- a/app/src/main/java/com/example/openeer/ui/library/LibraryActivity.kt
+++ b/app/src/main/java/com/example/openeer/ui/library/LibraryActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
 import com.example.openeer.R
 import com.example.openeer.databinding.ActivityLibraryBinding
 
@@ -16,10 +17,16 @@ class LibraryActivity : AppCompatActivity() {
         setContentView(b.root)
 
         setSupportActionBar(b.toolbar)
-        supportActionBar?.title = "Bibliothèque"
+        supportActionBar?.title = getString(R.string.library_title)
+
+        supportFragmentManager.addOnBackStackChangedListener {
+            updateActionBarForCurrentFragment()
+        }
 
         if (savedInstanceState == null) {
             showList()
+        } else {
+            updateActionBarForCurrentFragment()
         }
     }
 
@@ -33,27 +40,65 @@ class LibraryActivity : AppCompatActivity() {
             R.id.action_list -> { showList(); true }
             R.id.action_calendar -> { showCalendar(); true }
             R.id.action_map -> { showMap(); true } // ✅
+            R.id.action_merge_history -> { showMergeHistory(); true }
             else -> super.onOptionsItemSelected(item)
         }
     }
 
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+
     private fun showMap() {
+        clearBackStack()
         supportFragmentManager.beginTransaction()
             .replace(b.container.id, MapFragment.newInstance(), "maplibre") // ✅
             .commit()
+        updateActionBarForCurrentFragment()
     }
 
 
 
     private fun showList() {
+        clearBackStack()
         supportFragmentManager.beginTransaction()
             .replace(b.container.id, LibraryFragment.newInstance(), "list")
             .commit()
+        updateActionBarForCurrentFragment()
     }
 
     private fun showCalendar() {
+        clearBackStack()
         supportFragmentManager.beginTransaction()
             .replace(b.container.id, CalendarFragment.newInstance(), "calendar")
             .commit()
+        updateActionBarForCurrentFragment()
+    }
+
+    private fun showMergeHistory() {
+        supportFragmentManager.beginTransaction()
+            .replace(b.container.id, MergeHistoryFragment.newInstance(), "merge_history")
+            .addToBackStack("merge_history")
+            .commit()
+        updateActionBarForCurrentFragment()
+    }
+
+    private fun clearBackStack() {
+        if (supportFragmentManager.backStackEntryCount > 0) {
+            supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
+    }
+
+    private fun updateActionBarForCurrentFragment() {
+        val hasBackStack = supportFragmentManager.backStackEntryCount > 0
+        supportActionBar?.setDisplayHomeAsUpEnabled(hasBackStack)
+        val current = supportFragmentManager.findFragmentById(b.container.id)
+        val titleRes = if (current is MergeHistoryFragment) {
+            R.string.merge_history_title
+        } else {
+            R.string.library_title
+        }
+        supportActionBar?.title = getString(titleRes)
     }
 }

--- a/app/src/main/java/com/example/openeer/ui/library/MergeHistoryFragment.kt
+++ b/app/src/main/java/com/example/openeer/ui/library/MergeHistoryFragment.kt
@@ -1,0 +1,167 @@
+package com.example.openeer.ui.library
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.openeer.R
+import com.example.openeer.data.AppDatabase
+import com.example.openeer.data.MergeLogUiRow
+import com.example.openeer.data.NoteDao
+import com.example.openeer.data.NoteRepository
+import com.example.openeer.data.block.BlocksRepository
+import com.example.openeer.databinding.FragmentMergeHistoryBinding
+import com.example.openeer.databinding.ItemMergeHistoryBinding
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class MergeHistoryFragment : Fragment() {
+
+    private var _binding: FragmentMergeHistoryBinding? = null
+    private val binding get() = _binding!!
+
+    private lateinit var noteDao: NoteDao
+    private lateinit var noteRepository: NoteRepository
+
+    private val adapter = MergeHistoryAdapter(::onUndoClicked)
+    private val dateFormatter = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentMergeHistoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val ctx = requireContext().applicationContext
+        val db = AppDatabase.get(ctx)
+        noteDao = db.noteDao()
+        val blocksRepository = BlocksRepository(
+            blockDao = db.blockDao(),
+            noteDao = noteDao,
+            linkDao = db.blockLinkDao()
+        )
+        noteRepository = NoteRepository(noteDao, db.attachmentDao(), db.blockReadDao(), blocksRepository)
+
+        binding.recycler.layoutManager = LinearLayoutManager(requireContext())
+        binding.recycler.adapter = adapter
+
+        reload()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun reload() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            binding.progress.visibility = View.VISIBLE
+            try {
+                val rows = withContext(Dispatchers.IO) {
+                    noteDao.listMergeLogsUi()
+                }
+                adapter.submitList(rows)
+                binding.recycler.visibility = if (rows.isEmpty()) View.GONE else View.VISIBLE
+                binding.emptyView.visibility = if (rows.isEmpty()) View.VISIBLE else View.GONE
+            } finally {
+                binding.progress.visibility = View.GONE
+            }
+        }
+    }
+
+    private fun onUndoClicked(row: MergeLogUiRow) {
+        val sourceName = displayName(row.sourceTitle, row.sourceId)
+        val targetName = displayName(row.targetTitle, row.targetId)
+        AlertDialog.Builder(requireContext())
+            .setTitle(R.string.merge_history_confirm_title)
+            .setMessage(getString(R.string.merge_history_confirm_message, sourceName, targetName))
+            .setNegativeButton(R.string.action_cancel, null)
+            .setPositiveButton(R.string.merge_history_confirm_positive) { _, _ ->
+                undoMerge(row.id)
+            }
+            .show()
+    }
+
+    private fun undoMerge(mergeId: Long) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val result = withContext(Dispatchers.IO) {
+                runCatching { noteRepository.undoMergeById(mergeId) }
+            }
+
+            val undoResult = result.getOrNull()
+            if (undoResult != null && (undoResult.reassigned > 0 || undoResult.recreated > 0)) {
+                reload()
+                Snackbar.make(binding.root, R.string.merge_history_undo_success, Snackbar.LENGTH_SHORT).show()
+            } else {
+                Snackbar.make(binding.root, R.string.merge_history_undo_failed, Snackbar.LENGTH_SHORT).show()
+                if (undoResult != null) {
+                    reload()
+                }
+            }
+        }
+    }
+
+    private fun displayName(title: String?, id: Long): String {
+        return title ?: getString(R.string.merge_history_untitled, id)
+    }
+
+    private fun formatRow(row: MergeLogUiRow): String {
+        val sourceName = displayName(row.sourceTitle, row.sourceId)
+        val targetName = displayName(row.targetTitle, row.targetId)
+        val date = dateFormatter.format(Date(row.createdAt))
+        return getString(R.string.merge_history_item_format, sourceName, targetName, date)
+    }
+
+    companion object {
+        fun newInstance(): MergeHistoryFragment = MergeHistoryFragment()
+    }
+
+    private inner class MergeHistoryAdapter(
+        private val onUndo: (MergeLogUiRow) -> Unit
+    ) : ListAdapter<MergeLogUiRow, MergeHistoryViewHolder>(DiffCallback) {
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MergeHistoryViewHolder {
+            val inflater = LayoutInflater.from(parent.context)
+            val binding = ItemMergeHistoryBinding.inflate(inflater, parent, false)
+            return MergeHistoryViewHolder(binding)
+        }
+
+        override fun onBindViewHolder(holder: MergeHistoryViewHolder, position: Int) {
+            val item = getItem(position)
+            holder.binding.title.text = formatRow(item)
+            holder.binding.undoButton.setOnClickListener { onUndo(item) }
+        }
+
+        private object DiffCallback : DiffUtil.ItemCallback<MergeLogUiRow>() {
+            override fun areItemsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+
+    private class MergeHistoryViewHolder(val binding: ItemMergeHistoryBinding) :
+        RecyclerView.ViewHolder(binding.root)
+}
+

--- a/app/src/main/res/layout/fragment_merge_history.xml
+++ b/app/src/main/res/layout/fragment_merge_history.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <ProgressBar
+        android:id="@+id/progress"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:visibility="gone" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:clipToPadding="false"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp" />
+
+    <TextView
+        android:id="@+id/emptyView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="24dp"
+        android:text="@string/merge_history_empty"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_merge_history.xml
+++ b/app/src/main/res/layout/item_merge_history.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+        app:layout_constraintEnd_toStartOf="@id/undoButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/undoButton"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/merge_history_action_undo"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/menu_library.xml
+++ b/app/src/main/res/menu/menu_library.xml
@@ -14,10 +14,15 @@
         app:showAsAction="always"
         android:icon="@android:drawable/ic_menu_month" />
 
-<item
-    android:id="@+id/action_map"
-    android:title="Carte"
-    android:showAsAction="always"
-    android:icon="@android:drawable/ic_dialog_map" />
+    <item
+        android:id="@+id/action_map"
+        android:title="Carte"
+        android:showAsAction="always"
+        android:icon="@android:drawable/ic_dialog_map" />
+
+    <item
+        android:id="@+id/action_merge_history"
+        android:title="@string/merge_history_menu_item"
+        app:showAsAction="never" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -98,6 +98,7 @@
     <string name="zoom_out">Zoom arrière</string>
     <string name="recenter">Recentrer</string>
 
+    <string name="library_title">Bibliothèque</string>
     <string name="library_action_merge">Fusionner…</string>
     <string name="library_merge_dialog_title">Choisir la note cible</string>
     <string name="library_merge_dialog_message">Sélectionnez la note à conserver dans la fusion.</string>
@@ -122,5 +123,16 @@
     <string name="note_merge_empty">Aucune autre note disponible</string>
     <string name="action_undo">Annuler</string>
 
+    <string name="merge_history_title">Historique des fusions</string>
+    <string name="merge_history_menu_item">Historique des fusions…</string>
+    <string name="merge_history_empty">Aucune fusion enregistrée.</string>
+    <string name="merge_history_action_undo">Annuler</string>
+    <string name="merge_history_item_format">%1$s → %2$s · %3$s</string>
+    <string name="merge_history_untitled">Sans titre (#%1$d)</string>
+    <string name="merge_history_confirm_title">Annuler cette fusion ?</string>
+    <string name="merge_history_confirm_message">Annuler la fusion « %1$s → %2$s » ?</string>
+    <string name="merge_history_confirm_positive">Défusionner</string>
+    <string name="merge_history_undo_success">Défusion effectuée</string>
+    <string name="merge_history_undo_failed">Impossible d’annuler</string>
 
 </resources>


### PR DESCRIPTION
## Summary
- expose merge log rows for UI consumption via NoteDao
- add a merge history fragment that lists past merges and triggers cold undo
- surface the screen from the library toolbar menu and update strings/layouts

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e624e7bb2c832dbb771ed1faecac7d