### PR TITLE
fix: move merge history diff callback out of local scope

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/library/MergeHistoryFragment.kt
+++ b/app/src/main/java/com/example/openeer/ui/library/MergeHistoryFragment.kt
@@ -27,6 +27,16 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
+private object MergeLogDiff : DiffUtil.ItemCallback<MergeLogUiRow>() {
+    override fun areItemsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
+        return oldItem == newItem
+    }
+}
+
 class MergeHistoryFragment : Fragment() {
 
     private var _binding: FragmentMergeHistoryBinding? = null
@@ -136,7 +146,7 @@ class MergeHistoryFragment : Fragment() {
 
     private inner class MergeHistoryAdapter(
         private val onUndo: (MergeLogUiRow) -> Unit
-    ) : ListAdapter<MergeLogUiRow, MergeHistoryViewHolder>(DiffCallback) {
+    ) : ListAdapter<MergeLogUiRow, MergeHistoryViewHolder>(MergeLogDiff) {
 
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MergeHistoryViewHolder {
             val inflater = LayoutInflater.from(parent.context)
@@ -150,15 +160,6 @@ class MergeHistoryFragment : Fragment() {
             holder.binding.undoButton.setOnClickListener { onUndo(item) }
         }
 
-        private object DiffCallback : DiffUtil.ItemCallback<MergeLogUiRow>() {
-            override fun areItemsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
-                return oldItem.id == newItem.id
-            }
-
-            override fun areContentsTheSame(oldItem: MergeLogUiRow, newItem: MergeLogUiRow): Boolean {
-                return oldItem == newItem
-            }
-        }
     }
 
     private class MergeHistoryViewHolder(val binding: ItemMergeHistoryBinding) :


### PR DESCRIPTION
## Summary
- move the merge history diff callback object out of the adapter body so it is defined at file scope
- reference the shared diff callback from the adapter to prevent the local `object` compilation error

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e62ae48ab4832d969d3320ac807987