### PR TITLE
Hotfix: centralize debug flag and stabilize Room transactions

### DIFF
--- a/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
+++ b/app/src/main/java/com/example/openeer/data/block/BlockDao.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface BlockDao {
     @Insert
-    suspend fun insert(block: BlockEntity): Long
+    suspend fun insert(entity: BlockEntity): Long
 
     @Insert
     suspend fun insertAll(blocks: List<BlockEntity>): List<Long>
@@ -25,7 +25,10 @@ interface BlockDao {
     fun observeNoteWithBlocks(noteId: Long): Flow<NoteWithBlocks>
 
     @Query("SELECT * FROM blocks WHERE id = :id LIMIT 1")
-    suspend fun getById(id: Long): BlockEntity?
+    suspend fun getBlockById(id: Long): BlockEntity?
+
+    @Query("SELECT * FROM blocks WHERE noteId = :noteId ORDER BY position ASC")
+    suspend fun getBlocksForNote(noteId: Long): List<BlockEntity>
 
     @Query("SELECT MAX(position) FROM blocks WHERE noteId = :noteId")
     suspend fun getMaxPosition(noteId: Long): Int?
@@ -40,7 +43,7 @@ interface BlockDao {
     suspend fun getBlockIdsForNote(noteId: Long): List<Long>
 
     @Query("UPDATE blocks SET noteId = :targetNoteId WHERE id IN (:blockIds)")
-    suspend fun updateNoteIdForBlockIds(blockIds: List<Long>, targetNoteId: Long)
+    suspend fun reassignBlocksByIds(blockIds: List<Long>, targetNoteId: Long): Int
 
     // ✅ Utilisée par BlocksRepository.updateAudioTranscription(...)
     @Query("UPDATE blocks SET text = :newText, updatedAt = :updatedAt WHERE id = :blockId")

--- a/app/src/main/java/com/example/openeer/debug/NoteDebugGuards.kt
+++ b/app/src/main/java/com/example/openeer/debug/NoteDebugGuards.kt
@@ -1,7 +1,7 @@
 package com.example.openeer.debug
 
 import android.util.Log
-import com.example.openeer.BuildConfig
+import com.example.openeer.util.isDebug
 import java.util.ArrayDeque
 
 object NoteDebugGuards {
@@ -15,7 +15,7 @@ object NoteDebugGuards {
     }
 
     fun logTitleUpdate(noteId: Long) {
-        if (!BuildConfig.DEBUG) return
+        if (!isDebug) return
         val snapshot = currentNoteId
         synchronized(titleUpdates) {
             titleUpdates.addLast(TitleUpdateLog(noteId, snapshot, System.currentTimeMillis()))
@@ -37,7 +37,7 @@ object NoteDebugGuards {
     fun requireNoteId(noteId: Long?): Long {
         if (noteId == null || noteId <= 0) {
             val message = "Invalid noteId=$noteId"
-            if (BuildConfig.DEBUG) {
+            if (isDebug) {
                 throw IllegalStateException(message)
             } else {
                 Log.w("NoteGuards", message)

--- a/app/src/main/java/com/example/openeer/util/DebugOnly.kt
+++ b/app/src/main/java/com/example/openeer/util/DebugOnly.kt
@@ -1,0 +1,6 @@
+package com.example.openeer.util
+
+import com.example.openeer.BuildConfig
+
+inline val isDebug: Boolean
+    get() = BuildConfig.DEBUG


### PR DESCRIPTION
## Summary
- add a utility `isDebug` flag and replace direct `BuildConfig.DEBUG` checks across repositories, debug tools, and UI
- ensure repositories and the DB checker use the injected `AppDatabase`, Room `withTransaction`, and new DAO helpers while returning transaction results
- update coroutine usage in UI flows to launch suspend database work on `Dispatchers.IO`

## Testing
- ./gradlew assembleDebug *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e64d8652c0832db6e06aee3413d003