### PR TITLE
Extract MicUiStateController for mic UI state

### DIFF
--- a/app/src/main/java/com/example/openeer/ui/MicBarController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicBarController.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.lifecycleScope
 import com.example.openeer.R
 import com.example.openeer.audio.PcmRecorder
 import com.example.openeer.core.FeatureFlags
-import com.example.openeer.core.RecordingState
 import com.example.openeer.data.Note
 import com.example.openeer.data.NoteRepository
 import com.example.openeer.data.block.BlocksRepository
@@ -56,7 +55,6 @@ class MicBarController(
 ) {
     // Etat rec
     private var recorder: PcmRecorder? = null
-    private var state = RecordingState.IDLE
 
     // Gestes
     private var downX = 0f
@@ -67,6 +65,7 @@ class MicBarController(
     // Transcription live
     private var live: LiveTranscriber? = null
     private var lastWasHandsFree = false
+    private val micUiState = MicUiStateController(activity, binding, activity.lifecycleScope)
 
     private val bodyManager = BodyTranscriptionManager(
         binding.bodyEditor,
@@ -115,7 +114,7 @@ class MicBarController(
         downX = initialX
         switchedToHandsFree = false
         movedTooMuch = false
-        if (state == RecordingState.IDLE) startPttPress(allowNoNoteYet = true)
+        if (micUiState.isIdle()) startPttPress(allowNoNoteYet = true)
     }
 
     fun onTouch(ev: MotionEvent): Boolean {
@@ -124,10 +123,10 @@ class MicBarController(
                 downX = ev.x
                 switchedToHandsFree = false
                 movedTooMuch = false
-                if (state == RecordingState.IDLE) startPttPress(allowNoNoteYet = true)
+                if (micUiState.isIdle()) startPttPress(allowNoNoteYet = true)
             }
             MotionEvent.ACTION_MOVE -> {
-                if (state == RecordingState.RECORDING_PTT) {
+                if (micUiState.isRecordingPtt()) {
                     val dx = ev.x - downX
                     val adx = abs(dx)
                     if (adx > 8f) movedTooMuch = true
@@ -138,13 +137,12 @@ class MicBarController(
                 }
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
-                when (state) {
-                    RecordingState.RECORDING_PTT -> stopSegment()
-                    RecordingState.RECORDING_HANDS_FREE -> {
+                when {
+                    micUiState.isRecordingPtt() -> stopSegment()
+                    micUiState.isRecordingHandsFree() -> {
                         val adx = abs(ev.x - downX)
                         if (adx < 20f && !movedTooMuch) stopSegment()
                     }
-                    else -> Unit
                 }
             }
         }
@@ -158,17 +156,13 @@ class MicBarController(
             return
         }
 
-        state = RecordingState.RECORDING_PTT
+        micUiState.onPressToTalkStarted()
         currentAudioSessionId = nextAudioSessionId++
         if (recorder == null) recorder = PcmRecorder(activity)
         recorder?.start()
         Log.d("MicCtl", "Recorder.start()")
 
         segmentStartRealtime = SystemClock.elapsedRealtime()
-
-        binding.labelMic.text = "Enregistrement (PTT)…"
-        binding.iconMic.alpha = 1f
-        binding.txtActivity.text = "REC (PTT) • relâchez pour arrêter"
         binding.liveTranscriptionBar.isVisible = true
         binding.liveTranscriptionText.text = ""
 
@@ -212,18 +206,15 @@ class MicBarController(
     private fun newReqId(): String = UUID.randomUUID().toString().take(8)
 
     private fun switchPttToHandsFree() {
-        if (state != RecordingState.RECORDING_PTT) return
-        state = RecordingState.RECORDING_HANDS_FREE
-        binding.labelMic.text = "Mains libres — tap pour arrêter"
-        binding.txtActivity.text = "REC (mains libres) • tap pour arrêter"
-        Log.d("MicCtl", "Switch to hands-free")
+        if (!micUiState.isRecordingPtt()) return
+        micUiState.onHandsFreeEngaged()
     }
 
 
 
     private fun stopSegment() {
-        if (state == RecordingState.IDLE) return
-        lastWasHandsFree = (state == RecordingState.RECORDING_HANDS_FREE)
+        if (micUiState.isIdle()) return
+        lastWasHandsFree = micUiState.isRecordingHandsFree()
         val audioSessionId = currentAudioSessionId
         currentAudioSessionId = null
 
@@ -231,10 +222,7 @@ class MicBarController(
         recorder = null
         rec?.onPcmChunk = null
 
-        binding.iconMic.alpha = 0.9f
-        binding.labelMic.text = "Appuyez pour parler"
-        binding.txtActivity.text = "Prêt"
-        state = RecordingState.IDLE
+        micUiState.onRecordingStopped()
 
         activity.lifecycleScope.launch {
 
@@ -404,12 +392,7 @@ class MicBarController(
                             "decision=${earlyDecision.logToken} adaptive=${adaptiveDecision.mode} score=${"%.2f".format(adaptiveDecision.score)} note=$targetNoteId text=\"$sanitized\""
                         )
                     }
-                    if (FeatureFlags.voiceAdaptiveRoutingEnabled) {
-                        maybeShowAdaptiveFeedback(adaptiveDecision.mode)
-                        if (adaptiveDecision.mode == AdaptiveRouter.DecisionMode.REFINE_ONLY) {
-                            binding.txtActivity.text = activity.getString(R.string.voice_adaptive_feedback_refine)
-                        }
-                    }
+                    maybeShowAdaptiveFeedback(adaptiveDecision.mode)
 
                     val sessionBaselineSnapshot = activeSessionBaseline
                     val launchWhisper = {
@@ -640,8 +623,7 @@ class MicBarController(
 
 
 
-    fun isRecording(): Boolean =
-        state == RecordingState.RECORDING_PTT || state == RecordingState.RECORDING_HANDS_FREE
+    fun isRecording(): Boolean = micUiState.isRecording()
 
     private suspend fun removeEarlyCommandText(
         audioBlockId: Long,
@@ -1634,7 +1616,11 @@ class MicBarController(
             AdaptiveRouter.DecisionMode.REFLEX_THEN_REFINE -> R.string.voice_adaptive_feedback_pending
             AdaptiveRouter.DecisionMode.REFINE_ONLY -> R.string.voice_adaptive_feedback_refine
         }
-        showTopBubble(activity.getString(messageRes))
+        val message = activity.getString(messageRes)
+        showTopBubble(message)
+        if (mode == AdaptiveRouter.DecisionMode.REFINE_ONLY) {
+            micUiState.showTransientIndicator(message)
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/example/openeer/ui/MicUiStateController.kt
+++ b/app/src/main/java/com/example/openeer/ui/MicUiStateController.kt
@@ -1,0 +1,207 @@
+package com.example.openeer.ui
+
+import android.animation.ValueAnimator
+import android.os.SystemClock
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import com.example.openeer.R
+import com.example.openeer.core.RecordingState
+import com.example.openeer.databinding.ActivityMainBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Contrôle l'état UI de la barre micro : textes, animations et indicateurs temporaires.
+ */
+class MicUiStateController(
+    private val activity: AppCompatActivity,
+    private val binding: ActivityMainBinding,
+    private val scope: CoroutineScope,
+    private val clock: () -> Long = { SystemClock.elapsedRealtime() },
+) {
+
+    enum class Mode {
+        Idle,
+        RecordingPressToTalk,
+        RecordingHandsFree,
+    }
+
+    data class UiState(
+        val mode: Mode,
+        val recordingState: RecordingState,
+        val label: CharSequence,
+        val indicator: CharSequence,
+        val iconAlpha: Float,
+        val emittedAt: Long,
+    )
+
+    data class IndicatorOverride(
+        val message: CharSequence,
+        val expiresAt: Long,
+    )
+
+    fun interface Listener {
+        fun onUiStateChanged(state: UiState)
+    }
+
+    private val listeners = LinkedHashSet<Listener>()
+    private var indicatorOverride: IndicatorOverride? = null
+    private var indicatorJob: Job? = null
+    private var waveformAnimator: ValueAnimator? = null
+    private var currentMode: Mode = Mode.Idle
+    private var recordingState: RecordingState = RecordingState.IDLE
+
+    init {
+        applyUiState(buildState(Mode.Idle))
+    }
+
+    fun addListener(listener: Listener) {
+        listeners.add(listener)
+        listener.onUiStateChanged(buildState(currentMode))
+    }
+
+    fun removeListener(listener: Listener) {
+        listeners.remove(listener)
+    }
+
+    fun recordingState(): RecordingState = recordingState
+
+    fun isIdle(): Boolean = recordingState == RecordingState.IDLE
+
+    fun isRecording(): Boolean =
+        recordingState == RecordingState.RECORDING_PTT ||
+            recordingState == RecordingState.RECORDING_HANDS_FREE
+
+    fun isRecordingPtt(): Boolean = recordingState == RecordingState.RECORDING_PTT
+
+    fun isRecordingHandsFree(): Boolean = recordingState == RecordingState.RECORDING_HANDS_FREE
+
+    fun onPressToTalkStarted() {
+        transitionTo(Mode.RecordingPressToTalk)
+    }
+
+    fun onHandsFreeEngaged() {
+        if (!isRecordingPtt()) return
+        transitionTo(Mode.RecordingHandsFree)
+    }
+
+    fun onRecordingStopped() {
+        if (isIdle()) return
+        transitionTo(Mode.Idle)
+    }
+
+    fun showTransientIndicator(text: CharSequence, durationMs: Long = DEFAULT_INDICATOR_DURATION_MS) {
+        if (text.isBlank()) return
+        indicatorJob?.cancel()
+        val expiresAt = clock() + durationMs
+        indicatorOverride = IndicatorOverride(text, expiresAt)
+        binding.txtActivity.text = text
+        indicatorJob = scope.launch {
+            delay(durationMs)
+            indicatorOverride = null
+            applyIndicatorText()
+            Log.d(TAG, "indicator_reset duration=$durationMs")
+        }
+        Log.d(TAG, "indicator_override duration=$durationMs text=\"${text.take(32)}\"")
+    }
+
+    private fun transitionTo(mode: Mode) {
+        if (currentMode == mode) {
+            applyUiState(buildState(mode))
+            return
+        }
+        currentMode = mode
+        val newState = buildState(mode)
+        recordingState = newState.recordingState
+        if (mode != Mode.Idle) {
+            cancelIndicatorOverride()
+        }
+        applyUiState(newState)
+        listeners.forEach { listener -> listener.onUiStateChanged(newState) }
+        Log.d(TAG, "ui_state=${mode.name}")
+    }
+
+    private fun buildState(mode: Mode): UiState {
+        val label = when (mode) {
+            Mode.Idle -> activity.getString(R.string.mic_label_idle)
+            Mode.RecordingPressToTalk -> activity.getString(R.string.mic_label_recording_ptt)
+            Mode.RecordingHandsFree -> activity.getString(R.string.mic_label_recording_hands_free)
+        }
+        val indicator = when (mode) {
+            Mode.Idle -> activity.getString(R.string.mic_indicator_idle)
+            Mode.RecordingPressToTalk -> activity.getString(R.string.mic_indicator_recording_ptt)
+            Mode.RecordingHandsFree -> activity.getString(R.string.mic_indicator_recording_hands_free)
+        }
+        val alpha = if (mode == Mode.Idle) 0.9f else 1f
+        val recordingState = when (mode) {
+            Mode.Idle -> RecordingState.IDLE
+            Mode.RecordingPressToTalk -> RecordingState.RECORDING_PTT
+            Mode.RecordingHandsFree -> RecordingState.RECORDING_HANDS_FREE
+        }
+        return UiState(mode, recordingState, label, indicator, alpha, clock())
+    }
+
+    private fun applyUiState(state: UiState) {
+        binding.labelMic.text = state.label
+        binding.iconMic.alpha = state.iconAlpha
+        if (indicatorOverride == null) {
+            binding.txtActivity.text = state.indicator
+        }
+        if (state.mode == Mode.Idle) {
+            stopWaveformAnimation()
+        } else {
+            startWaveformAnimation()
+        }
+    }
+
+    private fun applyIndicatorText() {
+        val override = indicatorOverride
+        if (override != null) {
+            binding.txtActivity.text = override.message
+        } else {
+            binding.txtActivity.text = when (currentMode) {
+                Mode.Idle -> activity.getString(R.string.mic_indicator_idle)
+                Mode.RecordingPressToTalk -> activity.getString(R.string.mic_indicator_recording_ptt)
+                Mode.RecordingHandsFree -> activity.getString(R.string.mic_indicator_recording_hands_free)
+            }
+        }
+    }
+
+    private fun cancelIndicatorOverride() {
+        indicatorJob?.cancel()
+        indicatorJob = null
+        indicatorOverride = null
+    }
+
+    private fun startWaveformAnimation() {
+        if (waveformAnimator != null) return
+        waveformAnimator = ValueAnimator.ofFloat(1f, 1.08f).apply {
+            duration = WAVEFORM_ANIMATION_DURATION_MS
+            repeatCount = ValueAnimator.INFINITE
+            repeatMode = ValueAnimator.REVERSE
+            addUpdateListener { animator ->
+                val scale = animator.animatedValue as Float
+                binding.iconMic.scaleX = scale
+                binding.iconMic.scaleY = scale
+            }
+            start()
+        }
+        Log.d(TAG, "waveform_start")
+    }
+
+    private fun stopWaveformAnimation() {
+        waveformAnimator?.cancel()
+        waveformAnimator = null
+        binding.iconMic.scaleX = 1f
+        binding.iconMic.scaleY = 1f
+        Log.d(TAG, "waveform_stop")
+    }
+
+    companion object {
+        private const val TAG = "MicUiState"
+        const val DEFAULT_INDICATOR_DURATION_MS = 3_000L
+        private const val WAVEFORM_ANIMATION_DURATION_MS = 800L
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,7 +29,7 @@
     <!-- Statut en haut de l'écran -->
     <TextView
         android:id="@+id/txtActivity"
-        android:text="Appuyez pour parler"
+        android:text="@string/mic_label_idle"
         android:textStyle="bold"
         android:textSize="18sp"
         android:padding="12dp"
@@ -554,7 +554,7 @@
             android:contentDescription="Micro" />
         <TextView
             android:id="@+id/labelMic"
-            android:text="Appuyez pour parler"
+            android:text="@string/mic_label_idle"
             android:textSize="18sp"
             android:alpha="0.9"
             android:layout_marginStart="12dp"

--- a/app/src/main/res/layout/activity_note_detail.xml
+++ b/app/src/main/res/layout/activity_note_detail.xml
@@ -98,7 +98,7 @@
 
             <TextView
                 android:id="@+id/labelMic"
-                android:text="Appuyez pour parler"
+                android:text="@string/mic_label_idle"
                 android:textSize="18sp"
                 android:alpha="0.9"
                 android:layout_marginStart="12dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,11 @@
 <resources>
     <string name="app_name">OpenEER</string>
+    <string name="mic_label_idle">Appuyez pour parler</string>
+    <string name="mic_label_recording_ptt">Enregistrement (PTT)…</string>
+    <string name="mic_label_recording_hands_free">Mains libres — tap pour arrêter</string>
+    <string name="mic_indicator_idle">Prêt</string>
+    <string name="mic_indicator_recording_ptt">REC (PTT) • relâchez pour arrêter</string>
+    <string name="mic_indicator_recording_hands_free">REC (mains libres) • tap pour arrêter</string>
     <string name="notif_channel_reminders">Rappels OpenEER</string>
     <string name="notif_channel_reminders_desc">Notifications de rappel</string>
     <string name="notif_channel_alarms">Alarmes OpenEER</string>


### PR DESCRIPTION
## Summary
- add a dedicated MicUiStateController to drive the mic bar labels, indicator timers, waveform animation and logging
- delegate MicBarController to the new controller so UI state transitions and indicator messages are centralized
- move the repeated mic texts into resources and update the affected layouts to consume them

## Testing
- `./gradlew :app:lintDebug` *(fails: Android SDK not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c927ac780832daf5a287b5284e79a)